### PR TITLE
feat: change from email to oauthId, add oAuthProvider in user entity

### DIFF
--- a/backend/src/main/java/org/youcancook/gobong/domain/user/entity/OAuthProvider.java
+++ b/backend/src/main/java/org/youcancook/gobong/domain/user/entity/OAuthProvider.java
@@ -1,0 +1,5 @@
+package org.youcancook.gobong.domain.user.entity;
+
+public enum OAuthProvider {
+    KAKAO, GOOGLE
+}

--- a/backend/src/main/java/org/youcancook/gobong/domain/user/entity/User.java
+++ b/backend/src/main/java/org/youcancook/gobong/domain/user/entity/User.java
@@ -24,11 +24,11 @@ public class User {
     @Column(nullable = false)
     private String nickname;
 
-    @Column(nullable = false)
-    private String oauthId;
+    @Column(nullable = false, name = "oauth_id")
+    private String oAuthId;
 
     @Enumerated(EnumType.STRING)
-    @Column(nullable = false)
+    @Column(nullable = false, name = "oauth_provider")
     private OAuthProvider oAuthProvider;
 
     private String profileImageURL;
@@ -40,9 +40,9 @@ public class User {
     private List<Follow> following = new ArrayList<>();
 
     @Builder
-    public User(String nickname, String oauthId, OAuthProvider oAuthProvider, String profileImageURL) {
+    public User(String nickname, String oAuthId, OAuthProvider oAuthProvider, String profileImageURL) {
         this.nickname = nickname;
-        this.oauthId = oauthId;
+        this.oAuthId = oAuthId;
         this.oAuthProvider = oAuthProvider;
         this.profileImageURL = profileImageURL;
     }

--- a/backend/src/main/java/org/youcancook/gobong/domain/user/entity/User.java
+++ b/backend/src/main/java/org/youcancook/gobong/domain/user/entity/User.java
@@ -25,7 +25,11 @@ public class User {
     private String nickname;
 
     @Column(nullable = false)
-    private String email;
+    private String oauthId;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private OAuthProvider oAuthProvider;
 
     private String profileImageURL;
 
@@ -36,9 +40,10 @@ public class User {
     private List<Follow> following = new ArrayList<>();
 
     @Builder
-    public User(String nickname, String email, String profileImageURL) {
+    public User(String nickname, String oauthId, OAuthProvider oAuthProvider, String profileImageURL) {
         this.nickname = nickname;
-        this.email = email;
+        this.oauthId = oauthId;
+        this.oAuthProvider = oAuthProvider;
         this.profileImageURL = profileImageURL;
     }
 }


### PR DESCRIPTION
## 개요 🧾
User entity 수정

## 변경사항 🛠
- `email`을 `oauthId` 로 변경
- `oAuthProvider`컬럼 추가 및 enum 생성 (kakao, google)

