### PR TITLE
feat: Github Actions를 활용한 Docker CD(배포) 스크립트 작성

### DIFF
--- a/.github/workflows/backend-cd.yml
+++ b/.github/workflows/backend-cd.yml
@@ -1,0 +1,79 @@
+name: CD using Github Actions and Docker
+
+on:
+  push:
+    branches:
+      - master
+      - develop-backend
+
+permissions:
+  contents: read
+
+jobs:
+  CI-CD:
+    runs-on: ubuntu-latest
+    steps:
+
+      - uses: actions/checkout@v3
+      - name: Setup JDK 17
+        uses: actions/setup-java@v3
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+
+      - name: Gradle Caching
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
+          restore-keys: |
+            ${{ runner.os }}-gradle-
+
+      - name: make application.yml
+        if: |
+          contains(github.ref, 'master') ||
+          contains(github.ref, 'develop-backend')
+        run: |
+          cd ./backend/src/main/resources
+          touch ./application.yml
+          echo "${{ secrets.YML }}" > ./application.yml
+        shell: bash
+
+      - name: Grant execute permission for gradlew
+        run: chmod +x ./gradlew
+        working-directory: ./backend/
+
+      - name: Build with Gradle
+        run: ./gradlew build -x test
+        working-directory: ./backend/
+
+      - name: Docker build & push to dev
+        if: |
+          contains(github.ref, 'master') ||
+          contains(github.ref, 'develop-backend')
+        run: |
+          docker login -u ${{ secrets.DOCKER_USERNAME }} -p ${{ secrets.DOCKER_PASSWORD }}
+          docker build -t ${{ secrets.DOCKER_USERNAME }}/${{ secrets.DOCKER_REPOSITORY }} ./backend/
+          docker images
+          docker push ${{ secrets.DOCKER_USERNAME }}/${{ secrets.DOCKER_REPOSITORY }}
+
+      - name: Deploy to dev
+        uses: appleboy/ssh-action@master
+        id: deploy-dev
+        if: |
+          contains(github.ref, 'master') ||
+          contains(github.ref, 'develop-backend')
+        with:
+          host: ${{ secrets.HOST_DEV }}
+          username: ${{ secrets.USERNAME }}
+          port: 22
+          key: ${{ secrets.PRIVATE_KEY }}
+          script: |
+            cd ~/Gobong/backend/
+            sudo docker ps
+            sudo docker pull ${{ secrets.DOCKER_USERNAME }}/${{ secrets.DOCKER_REPOSITORY }}
+            sudo docker rm -f $(sudo docker ps -qa)
+            sudo docker-compose up -d
+            sudo docker image prune -f

--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -23,7 +23,17 @@ jobs:
           java-version: '17'
           distribution: 'temurin'
 
-      - name: Grant execute permisson for gradlew
+      - name: Gradle Caching
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
+          restore-keys: |
+            ${{ runner.os }}-gradle-    
+
+      - name: Grant execute permission for gradlew
         run: chmod +x ./gradlew
         working-directory: ./backend/
 

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,0 +1,7 @@
+FROM eclipse-temurin:17-jdk
+
+ARG JAR_FILE=build/libs/*.jar
+
+COPY ${JAR_FILE} app.jar
+
+ENTRYPOINT ["java", "-jar", "/app.jar"]

--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -4,6 +4,10 @@ plugins {
 	id 'io.spring.dependency-management' version '1.1.2'
 }
 
+jar{
+	enabled = false
+}
+
 group = 'org.youcancook'
 version = '0.0.1-SNAPSHOT'
 

--- a/backend/docker-compose.yml
+++ b/backend/docker-compose.yml
@@ -1,0 +1,9 @@
+version: '3'
+services:
+  app:
+    container_name: app
+    image: donghoony/gobong
+    expose:
+      - "8080"
+    ports:
+      - "8080:8080"


### PR DESCRIPTION
## 개요 🧾
<!-- 이곳에 PR의 내용을 간단하게 작성해주세요. -->
Github Actions를 활용한 CI를 바탕으로 AWS CD 스크립트를 작성했습니다.

AWS EC2에 도커를 띄울 수 있도록 설정해두었습니다.

docker-compose.yml의 변동사항이 있을 경우 ssh로 접속해서 풀 당겨와줘야 할 수 있습니다. jar 파일만 도커에 올려두기 때문이에요

이제 `master` 브랜치 혹은 `develop-backend` 브랜치에 영향을 주는 PR / Push의 경우 CI가 작동하고, Push가 일어날 경우 CD까지 작동합니다.

100줄 추가하는데 이렇게 오래걸릴 줄 상상도 못했네요..

## 주의사항 ⚠
<!-- 이곳에 리뷰어에게 할 말이나, 주의해야 하는 점에 대해서 작성해 주세요 -->
오타 확인해 주세요~!