### PR TITLE
feat: token manager 클래스 생성

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -36,6 +36,7 @@ dependencies {
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 
 	implementation 'io.jsonwebtoken:jjwt:0.9.1'
+	implementation 'javax.xml.bind:jaxb-api:2.3.1'
 }
 
 tasks.named('test') {

--- a/backend/src/main/java/org/youcancook/gobong/domain/authentication/service/TemporaryTokenService.java
+++ b/backend/src/main/java/org/youcancook/gobong/domain/authentication/service/TemporaryTokenService.java
@@ -35,12 +35,12 @@ public class TemporaryTokenService {
     }
 
     private LocalDateTime createExpiredAt() {
-        return clockService.localDateTimeNow().plusSeconds(temporaryTokenExpirationSeconds);
+        return clockService.getCurrentDateTime().plusSeconds(temporaryTokenExpirationSeconds);
     }
 
     @Transactional
     public void validTemporaryToken(String token) {
-        LocalDateTime localDateTimeNow = clockService.localDateTimeNow();
+        LocalDateTime localDateTimeNow = clockService.getCurrentDateTime();
         temporaryTokenRepository.findByTokenAndExpiredAtBefore(token, localDateTimeNow)
                 .ifPresentOrElse(
                         temporaryTokenRepository::delete,

--- a/backend/src/main/java/org/youcancook/gobong/domain/authentication/service/TemporaryTokenService.java
+++ b/backend/src/main/java/org/youcancook/gobong/domain/authentication/service/TemporaryTokenService.java
@@ -35,12 +35,12 @@ public class TemporaryTokenService {
     }
 
     private LocalDateTime createExpiredAt() {
-        return clockService.now().plusSeconds(temporaryTokenExpirationSeconds);
+        return clockService.localDateTimeNow().plusSeconds(temporaryTokenExpirationSeconds);
     }
 
     @Transactional
     public void validTemporaryToken(String token) {
-        LocalDateTime localDateTimeNow = clockService.now();
+        LocalDateTime localDateTimeNow = clockService.localDateTimeNow();
         temporaryTokenRepository.findByTokenAndExpiredAtBefore(token, localDateTimeNow)
                 .ifPresentOrElse(
                         temporaryTokenRepository::delete,

--- a/backend/src/main/java/org/youcancook/gobong/global/util/clock/ClockService.java
+++ b/backend/src/main/java/org/youcancook/gobong/global/util/clock/ClockService.java
@@ -4,7 +4,7 @@ import java.time.LocalDateTime;
 import java.util.Date;
 
 public interface ClockService {
-    LocalDateTime localDateTimeNow();
+    LocalDateTime getCurrentDateTime();
 
-    Date dateNow();
+    Date getCurrentDate();
 }

--- a/backend/src/main/java/org/youcancook/gobong/global/util/clock/ClockService.java
+++ b/backend/src/main/java/org/youcancook/gobong/global/util/clock/ClockService.java
@@ -1,7 +1,10 @@
 package org.youcancook.gobong.global.util.clock;
 
 import java.time.LocalDateTime;
+import java.util.Date;
 
 public interface ClockService {
-    LocalDateTime now();
+    LocalDateTime localDateTimeNow();
+
+    Date dateNow();
 }

--- a/backend/src/main/java/org/youcancook/gobong/global/util/clock/DefaultClockService.java
+++ b/backend/src/main/java/org/youcancook/gobong/global/util/clock/DefaultClockService.java
@@ -3,11 +3,17 @@ package org.youcancook.gobong.global.util.clock;
 import org.springframework.stereotype.Component;
 
 import java.time.LocalDateTime;
+import java.util.Date;
 
 @Component
 public class DefaultClockService implements ClockService {
     @Override
-    public LocalDateTime now() {
+    public LocalDateTime localDateTimeNow() {
         return LocalDateTime.now();
+    }
+
+    @Override
+    public Date dateNow() {
+        return new Date();
     }
 }

--- a/backend/src/main/java/org/youcancook/gobong/global/util/clock/DefaultClockService.java
+++ b/backend/src/main/java/org/youcancook/gobong/global/util/clock/DefaultClockService.java
@@ -8,12 +8,12 @@ import java.util.Date;
 @Component
 public class DefaultClockService implements ClockService {
     @Override
-    public LocalDateTime localDateTimeNow() {
+    public LocalDateTime getCurrentDateTime() {
         return LocalDateTime.now();
     }
 
     @Override
-    public Date dateNow() {
+    public Date getCurrentDate() {
         return new Date();
     }
 }

--- a/backend/src/main/java/org/youcancook/gobong/global/util/token/TokenDto.java
+++ b/backend/src/main/java/org/youcancook/gobong/global/util/token/TokenDto.java
@@ -1,0 +1,13 @@
+package org.youcancook.gobong.global.util.token;
+
+import lombok.*;
+
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+@AllArgsConstructor
+public class TokenDto {
+    private String grantType;
+    private String accessToken;
+    private String refreshToken;
+}

--- a/backend/src/main/java/org/youcancook/gobong/global/util/token/TokenManager.java
+++ b/backend/src/main/java/org/youcancook/gobong/global/util/token/TokenManager.java
@@ -1,0 +1,83 @@
+package org.youcancook.gobong.global.util.token;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Header;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import org.youcancook.gobong.global.util.clock.ClockService;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Date;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class TokenManager {
+
+    @Value("${token.secret}")
+    private String tokenSecret;
+
+    @Value("${token.access-token-expiration-seconds}")
+    private Long accessTokenExpirationSeconds;
+
+    @Value("${token.refresh-token-expiration-seconds}")
+    private Long refreshTokenExpirationSeconds;
+
+    private final ClockService clockService;
+
+    public TokenDto createTokenDto(Long userId) {
+        Date accessTokenExpiredAt = createAccessTokenExpirationTime();
+        Date refreshTokenExpiredAt = createRefreshTokenExpirationTime();
+
+        String accessToken = createAccessToken(userId, accessTokenExpiredAt);
+        String refreshToken = createRefreshToken(userId, refreshTokenExpiredAt);
+
+        return TokenDto.builder()
+                .grantType("Bearer")
+                .accessToken(accessToken)
+                .refreshToken(refreshToken)
+                .build();
+    }
+
+    private Date createAccessTokenExpirationTime() {
+        Date now = clockService.dateNow();
+        return new Date(now.getTime() + accessTokenExpirationSeconds * 1000);
+    }
+
+    private Date createRefreshTokenExpirationTime() {
+        Date now = clockService.dateNow();
+        return new Date(now.getTime() + refreshTokenExpirationSeconds * 1000);
+    }
+
+    private String createAccessToken(Long userId, Date expiredAt) {
+        Claims claims = createClaims(userId, TokenType.ACCESS);
+        return buildJwt(expiredAt, claims);
+    }
+
+    private String createRefreshToken(Long userId, Date expiredAt) {
+        Claims claims = createClaims(userId, TokenType.REFRESH);
+        return buildJwt(expiredAt, claims);
+    }
+
+    private Claims createClaims(Long userId, TokenType access) {
+        Claims claims = Jwts.claims();
+        claims.put("userId", userId);
+        claims.put(Claims.SUBJECT, access.name());
+        claims.put(Claims.ISSUER, "gobong.youcancook.org");
+        return claims;
+    }
+
+    private String buildJwt(Date expiredAt, Claims claims) {
+        return Jwts.builder()
+                .setHeaderParam(Header.TYPE, Header.JWT_TYPE)
+                .setClaims(claims)
+                .setIssuedAt(clockService.dateNow())
+                .setExpiration(expiredAt)
+                .signWith(SignatureAlgorithm.HS256, tokenSecret.getBytes(StandardCharsets.UTF_8))
+                .compact();
+    }
+}

--- a/backend/src/main/java/org/youcancook/gobong/global/util/token/TokenManager.java
+++ b/backend/src/main/java/org/youcancook/gobong/global/util/token/TokenManager.java
@@ -44,12 +44,12 @@ public class TokenManager {
     }
 
     private Date createAccessTokenExpirationTime() {
-        Date now = clockService.dateNow();
+        Date now = clockService.getCurrentDate();
         return new Date(now.getTime() + accessTokenExpirationSeconds * 1000);
     }
 
     private Date createRefreshTokenExpirationTime() {
-        Date now = clockService.dateNow();
+        Date now = clockService.getCurrentDate();
         return new Date(now.getTime() + refreshTokenExpirationSeconds * 1000);
     }
 
@@ -75,7 +75,7 @@ public class TokenManager {
         return Jwts.builder()
                 .setHeaderParam(Header.TYPE, Header.JWT_TYPE)
                 .setClaims(claims)
-                .setIssuedAt(clockService.dateNow())
+                .setIssuedAt(clockService.getCurrentDate())
                 .setExpiration(expiredAt)
                 .signWith(SignatureAlgorithm.HS256, tokenSecret.getBytes(StandardCharsets.UTF_8))
                 .compact();

--- a/backend/src/main/java/org/youcancook/gobong/global/util/token/TokenType.java
+++ b/backend/src/main/java/org/youcancook/gobong/global/util/token/TokenType.java
@@ -1,0 +1,5 @@
+package org.youcancook.gobong.global.util.token;
+
+public enum TokenType {
+    ACCESS, REFRESH;
+}

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -25,4 +25,5 @@ logging.level:
 token:
   secret: test
   access-token-expiration-seconds: 7200 # 2시간
+  refresh-token-expiration-seconds: 1209600 # 2주
   temporary-token-expiration-seconds: 600 # 10분

--- a/backend/src/test/java/org/youcancook/gobong/domain/authentication/service/TemporaryTokenServiceTest.java
+++ b/backend/src/test/java/org/youcancook/gobong/domain/authentication/service/TemporaryTokenServiceTest.java
@@ -38,7 +38,7 @@ class TemporaryTokenServiceTest {
     @BeforeEach
     void mockingClock() {
         final String localDateTimeOnTestEnv = "2023-07-16T10:15:30";
-        when(clockService.now())
+        when(clockService.localDateTimeNow())
                 .thenReturn(LocalDateTime.parse(localDateTimeOnTestEnv));
     }
 
@@ -61,7 +61,7 @@ class TemporaryTokenServiceTest {
         verify(temporaryTokenRepository, times(1)).save(argument.capture());
         assertThat(argument.getValue().getToken()).isEqualTo(token);
 
-        LocalDateTime expectedExpiredAt = clockService.now().plusSeconds(600);
+        LocalDateTime expectedExpiredAt = clockService.localDateTimeNow().plusSeconds(600);
         assertThat(argument.getValue().getExpiredAt()).isEqualTo(expectedExpiredAt);
     }
 
@@ -70,7 +70,7 @@ class TemporaryTokenServiceTest {
     void validTemporaryTokenFail() {
         // given
         final String token = UUID.randomUUID().toString();
-        when(temporaryTokenRepository.findByTokenAndExpiredAtBefore(token, clockService.now()))
+        when(temporaryTokenRepository.findByTokenAndExpiredAtBefore(token, clockService.localDateTimeNow()))
                 .thenReturn(Optional.empty());
 
         // when, then
@@ -78,7 +78,7 @@ class TemporaryTokenServiceTest {
                 () -> temporaryTokenService.validTemporaryToken(token));
 
         verify(temporaryTokenRepository, times(1))
-                .findByTokenAndExpiredAtBefore(token, clockService.now());
+                .findByTokenAndExpiredAtBefore(token, clockService.localDateTimeNow());
     }
 
     @Test
@@ -86,7 +86,7 @@ class TemporaryTokenServiceTest {
     void validTemporaryTokenSuccess() {
         // given
         final String token = UUID.randomUUID().toString();
-        when(temporaryTokenRepository.findByTokenAndExpiredAtBefore(token, clockService.now()))
+        when(temporaryTokenRepository.findByTokenAndExpiredAtBefore(token, clockService.localDateTimeNow()))
                 .thenReturn(Optional.of(new TemporaryToken(token, LocalDateTime.now())));
         doNothing().when(temporaryTokenRepository).delete(any(TemporaryToken.class));
 
@@ -95,7 +95,7 @@ class TemporaryTokenServiceTest {
 
         // then
         verify(temporaryTokenRepository, times(1))
-                .findByTokenAndExpiredAtBefore(token, clockService.now());
+                .findByTokenAndExpiredAtBefore(token, clockService.localDateTimeNow());
         verify(temporaryTokenRepository, times(1))
                 .delete(any(TemporaryToken.class));
     }

--- a/backend/src/test/java/org/youcancook/gobong/domain/authentication/service/TemporaryTokenServiceTest.java
+++ b/backend/src/test/java/org/youcancook/gobong/domain/authentication/service/TemporaryTokenServiceTest.java
@@ -38,7 +38,7 @@ class TemporaryTokenServiceTest {
     @BeforeEach
     void mockingClock() {
         final String localDateTimeOnTestEnv = "2023-07-16T10:15:30";
-        when(clockService.localDateTimeNow())
+        when(clockService.getCurrentDateTime())
                 .thenReturn(LocalDateTime.parse(localDateTimeOnTestEnv));
     }
 
@@ -61,7 +61,7 @@ class TemporaryTokenServiceTest {
         verify(temporaryTokenRepository, times(1)).save(argument.capture());
         assertThat(argument.getValue().getToken()).isEqualTo(token);
 
-        LocalDateTime expectedExpiredAt = clockService.localDateTimeNow().plusSeconds(600);
+        LocalDateTime expectedExpiredAt = clockService.getCurrentDateTime().plusSeconds(600);
         assertThat(argument.getValue().getExpiredAt()).isEqualTo(expectedExpiredAt);
     }
 
@@ -70,7 +70,7 @@ class TemporaryTokenServiceTest {
     void validTemporaryTokenFail() {
         // given
         final String token = UUID.randomUUID().toString();
-        when(temporaryTokenRepository.findByTokenAndExpiredAtBefore(token, clockService.localDateTimeNow()))
+        when(temporaryTokenRepository.findByTokenAndExpiredAtBefore(token, clockService.getCurrentDateTime()))
                 .thenReturn(Optional.empty());
 
         // when, then
@@ -78,7 +78,7 @@ class TemporaryTokenServiceTest {
                 () -> temporaryTokenService.validTemporaryToken(token));
 
         verify(temporaryTokenRepository, times(1))
-                .findByTokenAndExpiredAtBefore(token, clockService.localDateTimeNow());
+                .findByTokenAndExpiredAtBefore(token, clockService.getCurrentDateTime());
     }
 
     @Test
@@ -86,7 +86,7 @@ class TemporaryTokenServiceTest {
     void validTemporaryTokenSuccess() {
         // given
         final String token = UUID.randomUUID().toString();
-        when(temporaryTokenRepository.findByTokenAndExpiredAtBefore(token, clockService.localDateTimeNow()))
+        when(temporaryTokenRepository.findByTokenAndExpiredAtBefore(token, clockService.getCurrentDateTime()))
                 .thenReturn(Optional.of(new TemporaryToken(token, LocalDateTime.now())));
         doNothing().when(temporaryTokenRepository).delete(any(TemporaryToken.class));
 
@@ -95,7 +95,7 @@ class TemporaryTokenServiceTest {
 
         // then
         verify(temporaryTokenRepository, times(1))
-                .findByTokenAndExpiredAtBefore(token, clockService.localDateTimeNow());
+                .findByTokenAndExpiredAtBefore(token, clockService.getCurrentDateTime());
         verify(temporaryTokenRepository, times(1))
                 .delete(any(TemporaryToken.class));
     }

--- a/backend/src/test/java/org/youcancook/gobong/global/util/token/TokenManagerTest.java
+++ b/backend/src/test/java/org/youcancook/gobong/global/util/token/TokenManagerTest.java
@@ -37,7 +37,7 @@ class TokenManagerTest {
         String dateTimeOnTestEnv = "2023-08-25 10:15:30";
         SimpleDateFormat format = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
         Date date = format.parse(dateTimeOnTestEnv);
-        when(clockService.dateNow()).thenReturn(date);
+        when(clockService.getCurrentDate()).thenReturn(date);
 
         ReflectionTestUtils.setField(tokenManager, "tokenSecret", secretKey);
         ReflectionTestUtils.setField(tokenManager, "accessTokenExpirationSeconds", accessTokenExpirationSeconds);
@@ -58,7 +58,7 @@ class TokenManagerTest {
 
     private void testAccessToken(String accessToken) {
         Jws<Claims> claimsJws = Jwts.parser()
-                .setClock(() -> clockService.dateNow())
+                .setClock(() -> clockService.getCurrentDate())
                 .setSigningKey(secretKey.getBytes(StandardCharsets.UTF_8))
                 .parseClaimsJws(accessToken);
 
@@ -67,7 +67,7 @@ class TokenManagerTest {
         assertThat(claims.get("userId")).isEqualTo(1);
         assertThat(claims.getIssuer()).isEqualTo("gobong.youcancook.org");
 
-        Date expectedExpiredAt = new Date(clockService.dateNow().getTime() + accessTokenExpirationSeconds * 1000);
+        Date expectedExpiredAt = new Date(clockService.getCurrentDate().getTime() + accessTokenExpirationSeconds * 1000);
         assertThat(claims.getExpiration()).isEqualTo(expectedExpiredAt);
 
         JwsHeader header = claimsJws.getHeader();
@@ -76,7 +76,7 @@ class TokenManagerTest {
 
     private void testRefreshToken(String refreshToken) {
         Jws<Claims> claimsJws = Jwts.parser()
-                .setClock(() -> clockService.dateNow())
+                .setClock(() -> clockService.getCurrentDate())
                 .setSigningKey(secretKey.getBytes(StandardCharsets.UTF_8))
                 .parseClaimsJws(refreshToken);
 
@@ -85,7 +85,7 @@ class TokenManagerTest {
         assertThat(claims.get("userId")).isEqualTo(1);
         assertThat(claims.getIssuer()).isEqualTo("gobong.youcancook.org");
 
-        Date expectedExpiredAt = new Date(clockService.dateNow().getTime() + refreshTokenExpirationSeconds * 1000);
+        Date expectedExpiredAt = new Date(clockService.getCurrentDate().getTime() + refreshTokenExpirationSeconds * 1000);
         assertThat(claims.getExpiration()).isEqualTo(expectedExpiredAt);
 
         JwsHeader header = claimsJws.getHeader();

--- a/backend/src/test/java/org/youcancook/gobong/global/util/token/TokenManagerTest.java
+++ b/backend/src/test/java/org/youcancook/gobong/global/util/token/TokenManagerTest.java
@@ -1,0 +1,94 @@
+package org.youcancook.gobong.global.util.token;
+
+import io.jsonwebtoken.*;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.youcancook.gobong.global.util.clock.ClockService;
+
+import java.nio.charset.StandardCharsets;
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
+import java.util.Date;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class TokenManagerTest {
+
+    @InjectMocks
+    private TokenManager tokenManager;
+
+    @Mock
+    private ClockService clockService;
+
+    private final String secretKey = "testSecretKey";
+    private final Long accessTokenExpirationSeconds = 7200L;
+    private final Long refreshTokenExpirationSeconds = 1209600L;
+
+    @BeforeEach
+    void setUp() throws ParseException {
+        String dateTimeOnTestEnv = "2023-08-25 10:15:30";
+        SimpleDateFormat format = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
+        Date date = format.parse(dateTimeOnTestEnv);
+        when(clockService.dateNow()).thenReturn(date);
+
+        ReflectionTestUtils.setField(tokenManager, "tokenSecret", secretKey);
+        ReflectionTestUtils.setField(tokenManager, "accessTokenExpirationSeconds", accessTokenExpirationSeconds);
+        ReflectionTestUtils.setField(tokenManager, "refreshTokenExpirationSeconds", refreshTokenExpirationSeconds);
+    }
+
+    @Test
+    @DisplayName("토큰 생성")
+    void createTokenDto() {
+        // when
+        TokenDto tokenDto = tokenManager.createTokenDto(1L);
+
+        // then
+        assertThat(tokenDto.getGrantType()).isEqualTo("Bearer");
+        testAccessToken(tokenDto.getAccessToken());
+        testRefreshToken(tokenDto.getRefreshToken());
+    }
+
+    private void testAccessToken(String accessToken) {
+        Jws<Claims> claimsJws = Jwts.parser()
+                .setClock(() -> clockService.dateNow())
+                .setSigningKey(secretKey.getBytes(StandardCharsets.UTF_8))
+                .parseClaimsJws(accessToken);
+
+        Claims claims = claimsJws.getBody();
+        assertThat(claims.getSubject()).isEqualTo(TokenType.ACCESS.name());
+        assertThat(claims.get("userId")).isEqualTo(1);
+        assertThat(claims.getIssuer()).isEqualTo("gobong.youcancook.org");
+
+        Date expectedExpiredAt = new Date(clockService.dateNow().getTime() + accessTokenExpirationSeconds * 1000);
+        assertThat(claims.getExpiration()).isEqualTo(expectedExpiredAt);
+
+        JwsHeader header = claimsJws.getHeader();
+        assertThat(header.getType()).isEqualTo(Header.JWT_TYPE);
+    }
+
+    private void testRefreshToken(String refreshToken) {
+        Jws<Claims> claimsJws = Jwts.parser()
+                .setClock(() -> clockService.dateNow())
+                .setSigningKey(secretKey.getBytes(StandardCharsets.UTF_8))
+                .parseClaimsJws(refreshToken);
+
+        Claims claims = claimsJws.getBody();
+        assertThat(claims.getSubject()).isEqualTo(TokenType.REFRESH.name());
+        assertThat(claims.get("userId")).isEqualTo(1);
+        assertThat(claims.getIssuer()).isEqualTo("gobong.youcancook.org");
+
+        Date expectedExpiredAt = new Date(clockService.dateNow().getTime() + refreshTokenExpirationSeconds * 1000);
+        assertThat(claims.getExpiration()).isEqualTo(expectedExpiredAt);
+
+        JwsHeader header = claimsJws.getHeader();
+        assertThat(header.getType()).isEqualTo(Header.JWT_TYPE);
+    }
+}


### PR DESCRIPTION
## 개요 🧾
Clock Service 변경, Token Manager 클래스 생성

## 변경사항 🛠
### ClockService
- `LocalDateTime now()`를 `LocalDateTime localDateTimeNow()`로 메서드 변경
- `Date dateNow()` 추가

### TokenManager
- Token Claims에 들어가는 내용
  - userId, subject, issuer,  issuedAt, expiration
- 토큰 서명 암호화 알고리즘으로는 JWT에서 많이 쓰이는 `HS256`를 사용 (암호학 들으러 가자~)
