### PR TITLE
feat: 회원가입 서비스레이어 생성

### DIFF
--- a/backend/src/main/java/org/youcancook/gobong/domain/authentication/service/RefreshTokenService.java
+++ b/backend/src/main/java/org/youcancook/gobong/domain/authentication/service/RefreshTokenService.java
@@ -1,0 +1,25 @@
+package org.youcancook.gobong.domain.authentication.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.youcancook.gobong.domain.authentication.entity.RefreshToken;
+import org.youcancook.gobong.domain.authentication.repository.RefreshTokenRepository;
+import org.youcancook.gobong.global.util.token.TokenDto;
+
+@Service
+@RequiredArgsConstructor
+public class RefreshTokenService {
+
+    private final RefreshTokenRepository refreshTokenRepository;
+
+    @Transactional
+    public void saveRefreshToken(Long userId, TokenDto tokenDto) {
+        RefreshToken refreshToken = RefreshToken.builder()
+                .userId(userId)
+                .refreshToken(tokenDto.getRefreshToken())
+                .expiredAt(tokenDto.getRefreshTokenExpiredAt())
+                .build();
+        refreshTokenRepository.save(refreshToken);
+    }
+}

--- a/backend/src/main/java/org/youcancook/gobong/domain/user/dto/SignupDto.java
+++ b/backend/src/main/java/org/youcancook/gobong/domain/user/dto/SignupDto.java
@@ -1,0 +1,16 @@
+package org.youcancook.gobong.domain.user.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@AllArgsConstructor
+public class SignupDto {
+
+    private String nickname;
+    private String oAuthProvider;
+    private String oAuthId;
+    private String profileImageURL;
+}

--- a/backend/src/main/java/org/youcancook/gobong/domain/user/dto/request/SignupRequest.java
+++ b/backend/src/main/java/org/youcancook/gobong/domain/user/dto/request/SignupRequest.java
@@ -10,7 +10,7 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 public class SignupRequest {
 
-    @NotBlank(message = "provider는 필수입니다.")
+    @NotBlank(message = "nickname은 필수입니다.")
     private String nickname;
 
     @NotBlank(message = "provider는 필수입니다.")

--- a/backend/src/main/java/org/youcancook/gobong/domain/user/dto/request/SignupRequest.java
+++ b/backend/src/main/java/org/youcancook/gobong/domain/user/dto/request/SignupRequest.java
@@ -1,0 +1,26 @@
+package org.youcancook.gobong.domain.user.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = lombok.AccessLevel.PRIVATE)
+@AllArgsConstructor
+public class SignupRequest {
+
+    @NotBlank(message = "provider는 필수입니다.")
+    private String nickname;
+
+    @NotBlank(message = "provider는 필수입니다.")
+    private String provider;
+
+    @NotBlank(message = "oAuthId는 필수입니다.")
+    private String oauthId;
+
+    @NotBlank(message = "temporaryToken은 필수입니다.")
+    private String temporaryToken;
+
+    private String profileImageURL;
+}

--- a/backend/src/main/java/org/youcancook/gobong/domain/user/dto/response/SignupResponse.java
+++ b/backend/src/main/java/org/youcancook/gobong/domain/user/dto/response/SignupResponse.java
@@ -13,7 +13,7 @@ public class SignupResponse {
     private String accessToken;
     private String refreshToken;
 
-    public static SignupResponse of(TokenDto tokenDto) {
+    public static SignupResponse From(TokenDto tokenDto) {
         return SignupResponse.builder()
                 .grantType(tokenDto.getGrantType())
                 .accessToken(tokenDto.getAccessToken())

--- a/backend/src/main/java/org/youcancook/gobong/domain/user/dto/response/SignupResponse.java
+++ b/backend/src/main/java/org/youcancook/gobong/domain/user/dto/response/SignupResponse.java
@@ -13,7 +13,7 @@ public class SignupResponse {
     private String accessToken;
     private String refreshToken;
 
-    public static SignupResponse From(TokenDto tokenDto) {
+    public static SignupResponse from(TokenDto tokenDto) {
         return SignupResponse.builder()
                 .grantType(tokenDto.getGrantType())
                 .accessToken(tokenDto.getAccessToken())

--- a/backend/src/main/java/org/youcancook/gobong/domain/user/dto/response/SignupResponse.java
+++ b/backend/src/main/java/org/youcancook/gobong/domain/user/dto/response/SignupResponse.java
@@ -1,0 +1,23 @@
+package org.youcancook.gobong.domain.user.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import org.youcancook.gobong.global.util.token.TokenDto;
+
+@Getter
+@Builder
+@AllArgsConstructor
+public class SignupResponse {
+    private String grantType;
+    private String accessToken;
+    private String refreshToken;
+
+    public static SignupResponse of(TokenDto tokenDto) {
+        return SignupResponse.builder()
+                .grantType(tokenDto.getGrantType())
+                .accessToken(tokenDto.getAccessToken())
+                .refreshToken(tokenDto.getRefreshToken())
+                .build();
+    }
+}

--- a/backend/src/main/java/org/youcancook/gobong/domain/user/exception/DuplicationNicknameException.java
+++ b/backend/src/main/java/org/youcancook/gobong/domain/user/exception/DuplicationNicknameException.java
@@ -1,0 +1,10 @@
+package org.youcancook.gobong.domain.user.exception;
+
+import org.youcancook.gobong.global.error.ErrorCode;
+import org.youcancook.gobong.global.error.exception.IllegalException;
+
+public class DuplicationNicknameException extends IllegalException {
+    public DuplicationNicknameException() {
+        super(ErrorCode.DUPLICATE_NICKNAME);
+    }
+}

--- a/backend/src/main/java/org/youcancook/gobong/domain/user/repository/UserRepository.java
+++ b/backend/src/main/java/org/youcancook/gobong/domain/user/repository/UserRepository.java
@@ -10,4 +10,6 @@ import java.util.Optional;
 public interface UserRepository extends JpaRepository<User, Long> {
     @Query("SELECT u FROM User u WHERE u.oAuthProvider =:oAuthProvider AND u.oAuthId =:oAuthId")
     Optional<User> findByOAuthProviderAndOAuthId(OAuthProvider oAuthProvider, String oAuthId);
+
+    boolean existsByNickname(String nickname);
 }

--- a/backend/src/main/java/org/youcancook/gobong/domain/user/service/UserLoginService.java
+++ b/backend/src/main/java/org/youcancook/gobong/domain/user/service/UserLoginService.java
@@ -3,8 +3,7 @@ package org.youcancook.gobong.domain.user.service;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import org.youcancook.gobong.domain.authentication.entity.RefreshToken;
-import org.youcancook.gobong.domain.authentication.repository.RefreshTokenRepository;
+import org.youcancook.gobong.domain.authentication.service.RefreshTokenService;
 import org.youcancook.gobong.domain.user.dto.response.LoginResponse;
 import org.youcancook.gobong.domain.user.entity.OAuthProvider;
 import org.youcancook.gobong.domain.user.entity.User;
@@ -18,7 +17,7 @@ import org.youcancook.gobong.global.util.token.TokenManager;
 public class UserLoginService {
 
     private final UserRepository userRepository;
-    private final RefreshTokenRepository refreshTokenRepository;
+    private final RefreshTokenService refreshTokenService;
     private final TokenManager tokenManager;
 
     @Transactional
@@ -26,17 +25,9 @@ public class UserLoginService {
         OAuthProvider oAuthProvider = OAuthProvider.from(provider);
         User user = userRepository.findByOAuthProviderAndOAuthId(oAuthProvider, oAuthId)
                 .orElseThrow(UserNotFoundException::new);
-        TokenDto tokenDto = tokenManager.createTokenDto(user.getId());
-        saveRefreshToken(user.getId(), tokenDto);
-        return LoginResponse.of(tokenDto);
-    }
 
-    private void saveRefreshToken(Long userId, TokenDto tokenDto) {
-        RefreshToken refreshToken = RefreshToken.builder()
-                .userId(userId)
-                .refreshToken(tokenDto.getRefreshToken())
-                .expiredAt(tokenDto.getRefreshTokenExpiredAt())
-                .build();
-        refreshTokenRepository.save(refreshToken);
+        TokenDto tokenDto = tokenManager.createTokenDto(user.getId());
+        refreshTokenService.saveRefreshToken(user.getId(), tokenDto);
+        return LoginResponse.of(tokenDto);
     }
 }

--- a/backend/src/main/java/org/youcancook/gobong/domain/user/service/UserSignupService.java
+++ b/backend/src/main/java/org/youcancook/gobong/domain/user/service/UserSignupService.java
@@ -32,7 +32,7 @@ public class UserSignupService {
 
         TokenDto tokenDto = tokenManager.createTokenDto(user.getId());
         refreshTokenService.saveRefreshToken(user.getId(), tokenDto);
-        return SignupResponse.of(tokenDto);
+        return SignupResponse.From(tokenDto);
     }
 
     private User createUser(SignupDto signupDto) {

--- a/backend/src/main/java/org/youcancook/gobong/domain/user/service/UserSignupService.java
+++ b/backend/src/main/java/org/youcancook/gobong/domain/user/service/UserSignupService.java
@@ -1,0 +1,51 @@
+package org.youcancook.gobong.domain.user.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.youcancook.gobong.domain.authentication.service.RefreshTokenService;
+import org.youcancook.gobong.domain.user.dto.SignupDto;
+import org.youcancook.gobong.domain.user.dto.response.SignupResponse;
+import org.youcancook.gobong.domain.user.entity.OAuthProvider;
+import org.youcancook.gobong.domain.user.entity.User;
+import org.youcancook.gobong.domain.user.exception.DuplicationNicknameException;
+import org.youcancook.gobong.domain.user.repository.UserRepository;
+import org.youcancook.gobong.global.util.token.TokenDto;
+import org.youcancook.gobong.global.util.token.TokenManager;
+
+@Service
+@RequiredArgsConstructor
+public class UserSignupService {
+
+    private final RefreshTokenService refreshTokenService;
+    private final UserRepository userRepository;
+    private final TokenManager tokenManager;
+
+    @Transactional
+    public SignupResponse signup(SignupDto signupDto) {
+        if (isDuplicateNickname(signupDto.getNickname())) {
+            throw new DuplicationNicknameException();
+        }
+
+        User user = createUser(signupDto);
+        userRepository.save(user);
+
+        TokenDto tokenDto = tokenManager.createTokenDto(user.getId());
+        refreshTokenService.saveRefreshToken(user.getId(), tokenDto);
+        return SignupResponse.of(tokenDto);
+    }
+
+    private User createUser(SignupDto signupDto) {
+        OAuthProvider oAuthProvider = OAuthProvider.from(signupDto.getOAuthProvider());
+        return User.builder()
+                .oAuthProvider(oAuthProvider)
+                .oAuthId(signupDto.getOAuthId())
+                .nickname(signupDto.getNickname())
+                .profileImageURL(signupDto.getProfileImageURL())
+                .build();
+    }
+
+    public boolean isDuplicateNickname(String nickname) {
+        return userRepository.existsByNickname(nickname);
+    }
+}

--- a/backend/src/main/java/org/youcancook/gobong/domain/user/service/UserSignupService.java
+++ b/backend/src/main/java/org/youcancook/gobong/domain/user/service/UserSignupService.java
@@ -32,7 +32,7 @@ public class UserSignupService {
 
         TokenDto tokenDto = tokenManager.createTokenDto(user.getId());
         refreshTokenService.saveRefreshToken(user.getId(), tokenDto);
-        return SignupResponse.From(tokenDto);
+        return SignupResponse.from(tokenDto);
     }
 
     private User createUser(SignupDto signupDto) {

--- a/backend/src/main/java/org/youcancook/gobong/global/error/ErrorCode.java
+++ b/backend/src/main/java/org/youcancook/gobong/global/error/ErrorCode.java
@@ -28,6 +28,7 @@ public enum ErrorCode {
     OAUTH_PROVIDER_NOT_FOUND(HttpStatus.NOT_FOUND, "O004", "OAuth provider를 찾을 수 없습니다."),
 
     // User
+    DUPLICATE_NICKNAME(HttpStatus.BAD_REQUEST, "U001", "이미 등록된 닉네임입니다."),
     USER_NOT_FOUND(HttpStatus.NOT_FOUND, "U004", "유저를 찾을 수 없습니다."),
 
     // Recipe

--- a/backend/src/test/java/org/youcancook/gobong/domain/authentication/service/RefreshTokenServiceTest.java
+++ b/backend/src/test/java/org/youcancook/gobong/domain/authentication/service/RefreshTokenServiceTest.java
@@ -1,0 +1,59 @@
+package org.youcancook.gobong.domain.authentication.service;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.youcancook.gobong.domain.authentication.entity.RefreshToken;
+import org.youcancook.gobong.domain.authentication.repository.RefreshTokenRepository;
+import org.youcancook.gobong.global.util.token.TokenDto;
+
+import java.util.Date;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class RefreshTokenServiceTest {
+
+    @InjectMocks
+    private RefreshTokenService refreshTokenService;
+
+    @Mock
+    private RefreshTokenRepository refreshTokenRepository;
+
+    @Test
+    @DisplayName("리프레시 토큰 저장")
+    void saveRefreshToken() {
+        // given
+        when(refreshTokenRepository.save(any(RefreshToken.class)))
+                .then(invocation -> invocation.getArgument(0));
+
+        // when
+        TokenDto tokenDto = createTestTokenDto();
+        refreshTokenService.saveRefreshToken(1L, tokenDto);
+
+        // then
+        ArgumentCaptor<RefreshToken> argument = ArgumentCaptor.forClass(RefreshToken.class);
+        verify(refreshTokenRepository, times(1)).save(argument.capture());
+
+        RefreshToken savedRefreshToken = argument.getValue();
+        assertThat(savedRefreshToken.getUserId()).isEqualTo(1L);
+        assertThat(savedRefreshToken.getRefreshToken()).isEqualTo(tokenDto.getRefreshToken());
+        assertThat(savedRefreshToken.getExpiredAt()).isEqualTo(tokenDto.getRefreshTokenExpiredAt());
+    }
+
+    private TokenDto createTestTokenDto() {
+        return TokenDto.builder()
+                .grantType("Bearer")
+                .accessToken("accessToken")
+                .refreshToken("refreshToken")
+                .accessTokenExpiredAt(new Date())
+                .refreshTokenExpiredAt(new Date())
+                .build();
+    }
+}

--- a/backend/src/test/java/org/youcancook/gobong/domain/user/service/UserLoginServiceTest.java
+++ b/backend/src/test/java/org/youcancook/gobong/domain/user/service/UserLoginServiceTest.java
@@ -8,6 +8,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.test.util.ReflectionTestUtils;
 import org.youcancook.gobong.domain.authentication.repository.RefreshTokenRepository;
+import org.youcancook.gobong.domain.authentication.service.RefreshTokenService;
 import org.youcancook.gobong.domain.user.dto.response.LoginResponse;
 import org.youcancook.gobong.domain.user.entity.OAuthProvider;
 import org.youcancook.gobong.domain.user.entity.User;
@@ -22,7 +23,7 @@ import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
@@ -35,10 +36,10 @@ class UserLoginServiceTest {
     private UserRepository userRepository;
 
     @Mock
-    private RefreshTokenRepository refreshTokenRepository;
+    private TokenManager tokenManager;
 
     @Mock
-    private TokenManager tokenManager;
+    private RefreshTokenService refreshTokenService;
 
     @Test
     @DisplayName("로그인 성공")
@@ -51,8 +52,7 @@ class UserLoginServiceTest {
                 .thenReturn(Optional.of(user));
         when(tokenManager.createTokenDto(1L))
                 .thenReturn(tokenDto);
-        when(refreshTokenRepository.save(any()))
-                .thenReturn(null);
+        doNothing().when(refreshTokenService).saveRefreshToken(1L, tokenDto);
 
         // when
         LoginResponse result = userLoginService.login("kakao", oAuthId);

--- a/backend/src/test/java/org/youcancook/gobong/domain/user/service/UserLoginServiceTest.java
+++ b/backend/src/test/java/org/youcancook/gobong/domain/user/service/UserLoginServiceTest.java
@@ -7,7 +7,6 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.test.util.ReflectionTestUtils;
-import org.youcancook.gobong.domain.authentication.repository.RefreshTokenRepository;
 import org.youcancook.gobong.domain.authentication.service.RefreshTokenService;
 import org.youcancook.gobong.domain.user.dto.response.LoginResponse;
 import org.youcancook.gobong.domain.user.entity.OAuthProvider;

--- a/backend/src/test/java/org/youcancook/gobong/domain/user/service/UserSignupServiceTest.java
+++ b/backend/src/test/java/org/youcancook/gobong/domain/user/service/UserSignupServiceTest.java
@@ -1,0 +1,102 @@
+package org.youcancook.gobong.domain.user.service;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.youcancook.gobong.domain.authentication.service.RefreshTokenService;
+import org.youcancook.gobong.domain.user.dto.SignupDto;
+import org.youcancook.gobong.domain.user.dto.response.SignupResponse;
+import org.youcancook.gobong.domain.user.entity.OAuthProvider;
+import org.youcancook.gobong.domain.user.entity.User;
+import org.youcancook.gobong.domain.user.exception.DuplicationNicknameException;
+import org.youcancook.gobong.domain.user.repository.UserRepository;
+import org.youcancook.gobong.global.util.token.TokenDto;
+import org.youcancook.gobong.global.util.token.TokenManager;
+
+import java.util.Date;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class UserSignupServiceTest {
+
+    @InjectMocks
+    private UserSignupService userSignupService;
+
+    @Mock
+    private UserRepository userRepository;
+
+    @Mock
+    private RefreshTokenService refreshTokenService;
+
+    @Mock
+    private TokenManager tokenManager;
+
+    @Test
+    @DisplayName("회원가입 성공")
+    void signupSuccess() {
+        // given
+        TokenDto tokenDto = createTestTokenDto();
+        when(userRepository.existsByNickname("nickname"))
+                .thenReturn(false);
+        when(tokenManager.createTokenDto(1L))
+                .thenReturn(tokenDto);
+        doNothing().when(refreshTokenService).saveRefreshToken(1L, tokenDto);
+        when(userRepository.save(any(User.class)))
+                .then(invocation -> {
+                    User savedUser = invocation.getArgument(0);
+                    ReflectionTestUtils.setField(savedUser, "id", 1L);
+                    return savedUser;
+                });
+
+        // when
+        SignupDto signupDto = SignupDto.builder()
+                .oAuthProvider(OAuthProvider.KAKAO.name())
+                .nickname("nickname")
+                .oAuthId("123456789")
+                .profileImageURL("profileImageURL")
+                .build();
+        SignupResponse result = userSignupService.signup(signupDto);
+
+        // then
+        assertThat(result.getGrantType()).isEqualTo(tokenDto.getGrantType());
+        assertThat(result.getAccessToken()).isEqualTo(tokenDto.getAccessToken());
+        assertThat(result.getRefreshToken()).isEqualTo(tokenDto.getRefreshToken());
+    }
+
+    @Test
+    @DisplayName("회원가입 실패 - 중복된 닉네임")
+    void signupFailByDuplicatedNickname() {
+        // given
+        when(userRepository.existsByNickname(any(String.class)))
+                .thenReturn(true);
+
+        // when
+        SignupDto signupDto = SignupDto.builder()
+                .oAuthProvider(OAuthProvider.KAKAO.name())
+                .nickname("nickname")
+                .oAuthId("123456789")
+                .profileImageURL("profileImageURL")
+                .build();
+        assertThrows(DuplicationNicknameException.class,
+                () -> userSignupService.signup(signupDto));
+    }
+
+    private TokenDto createTestTokenDto() {
+        return TokenDto.builder()
+                .grantType("Bearer")
+                .accessToken("accessToken")
+                .refreshToken("refreshToken")
+                .accessTokenExpiredAt(new Date())
+                .refreshTokenExpiredAt(new Date())
+                .build();
+    }
+}


### PR DESCRIPTION
## 개요 🧾
RefreshTokenService 생성 및 메서드 이동
UserSignupService 생성

## 변경사항 🛠
RefreshToken 관련 메서드가 늘어날 것 같아서 RefreshTokenService를 생성하고 `saveRefreshToken()` 메서드를 이동시켰습니다. 

