### PR TITLE
feat: Argument Resolver 추가

### DIFF
--- a/backend/src/main/java/org/youcancook/gobong/global/config/WebConfig.java
+++ b/backend/src/main/java/org/youcancook/gobong/global/config/WebConfig.java
@@ -1,0 +1,21 @@
+package org.youcancook.gobong.global.config;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+import org.youcancook.gobong.global.resolver.UserIdArgumentResolver;
+
+import java.util.List;
+
+@Configuration
+@RequiredArgsConstructor
+public class WebConfig implements WebMvcConfigurer {
+
+    private final UserIdArgumentResolver userEmailArgumentResolver;
+
+    @Override
+    public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
+        resolvers.add(userEmailArgumentResolver);
+    }
+}

--- a/backend/src/main/java/org/youcancook/gobong/global/config/WebConfig.java
+++ b/backend/src/main/java/org/youcancook/gobong/global/config/WebConfig.java
@@ -4,7 +4,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.method.support.HandlerMethodArgumentResolver;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
-import org.youcancook.gobong.global.resolver.UserIdArgumentResolver;
+import org.youcancook.gobong.global.resolver.LoginUserIdArgumentResolver;
 
 import java.util.List;
 
@@ -12,7 +12,7 @@ import java.util.List;
 @RequiredArgsConstructor
 public class WebConfig implements WebMvcConfigurer {
 
-    private final UserIdArgumentResolver userEmailArgumentResolver;
+    private final LoginUserIdArgumentResolver userEmailArgumentResolver;
 
     @Override
     public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {

--- a/backend/src/main/java/org/youcancook/gobong/global/error/ErrorCode.java
+++ b/backend/src/main/java/org/youcancook/gobong/global/error/ErrorCode.java
@@ -23,6 +23,7 @@ public enum ErrorCode {
     INVALID_TOKEN(HttpStatus.UNAUTHORIZED, "A003", "유효하지 않은 토큰입니다."),
     EXPIRED_TOKEN(HttpStatus.UNAUTHORIZED, "A004", "만료된 토큰입니다."),
     UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "A005", "Unauthorized"),
+    INVALID_TOKEN_TYPE(HttpStatus.UNAUTHORIZED, "A006", "잘못된 토큰 타입입니다."),
 
     // OAuth
     OAUTH_PROVIDER_NOT_FOUND(HttpStatus.NOT_FOUND, "O004", "OAuth provider를 찾을 수 없습니다."),

--- a/backend/src/main/java/org/youcancook/gobong/global/resolver/LoginUserId.java
+++ b/backend/src/main/java/org/youcancook/gobong/global/resolver/LoginUserId.java
@@ -7,5 +7,5 @@ import java.lang.annotation.Target;
 
 @Target(ElementType.PARAMETER)
 @Retention(RetentionPolicy.RUNTIME)
-public @interface UserId {
+public @interface LoginUserId {
 }

--- a/backend/src/main/java/org/youcancook/gobong/global/resolver/LoginUserIdArgumentResolver.java
+++ b/backend/src/main/java/org/youcancook/gobong/global/resolver/LoginUserIdArgumentResolver.java
@@ -19,7 +19,7 @@ import org.youcancook.gobong.global.util.token.exception.NotBearerGrantTypeExcep
 public class LoginUserIdArgumentResolver implements HandlerMethodArgumentResolver {
 
     private final TokenManager tokenManager;
-    private final String grantTokenType = "Bearer";
+    private final String GRANT_TOKEN_TYPE = "Bearer";
 
     @Override
     public boolean supportsParameter(MethodParameter parameter) {
@@ -47,12 +47,12 @@ public class LoginUserIdArgumentResolver implements HandlerMethodArgumentResolve
     }
 
     private void validateGrantType(String authorizationHeader) {
-        if (!authorizationHeader.startsWith(grantTokenType)) {
+        if (!authorizationHeader.startsWith(GRANT_TOKEN_TYPE)) {
             throw new NotBearerGrantTypeException();
         }
     }
 
     private String extractToken(String authorizationHeader) {
-        return authorizationHeader.substring(grantTokenType.length()).trim();
+        return authorizationHeader.substring(GRANT_TOKEN_TYPE.length()).trim();
     }
 }

--- a/backend/src/main/java/org/youcancook/gobong/global/resolver/LoginUserIdArgumentResolver.java
+++ b/backend/src/main/java/org/youcancook/gobong/global/resolver/LoginUserIdArgumentResolver.java
@@ -19,6 +19,7 @@ import org.youcancook.gobong.global.util.token.exception.NotBearerGrantTypeExcep
 public class LoginUserIdArgumentResolver implements HandlerMethodArgumentResolver {
 
     private final TokenManager tokenManager;
+    private final String grantTokenType = "Bearer";
 
     @Override
     public boolean supportsParameter(MethodParameter parameter) {
@@ -46,13 +47,12 @@ public class LoginUserIdArgumentResolver implements HandlerMethodArgumentResolve
     }
 
     private void validateGrantType(String authorizationHeader) {
-        String[] authorizations = authorizationHeader.split(" ");
-        if (authorizations.length < 2 || (!"Bearer".equalsIgnoreCase(authorizations[0]))) {
+        if (!authorizationHeader.startsWith(grantTokenType)) {
             throw new NotBearerGrantTypeException();
         }
     }
 
     private String extractToken(String authorizationHeader) {
-        return authorizationHeader.split(" ")[1];
+        return authorizationHeader.substring(grantTokenType.length()).trim();
     }
 }

--- a/backend/src/main/java/org/youcancook/gobong/global/resolver/LoginUserIdArgumentResolver.java
+++ b/backend/src/main/java/org/youcancook/gobong/global/resolver/LoginUserIdArgumentResolver.java
@@ -13,13 +13,13 @@ import org.youcancook.gobong.global.util.token.TokenManager;
 
 @Component
 @RequiredArgsConstructor
-public class UserIdArgumentResolver implements HandlerMethodArgumentResolver {
+public class LoginUserIdArgumentResolver implements HandlerMethodArgumentResolver {
 
     private final TokenManager tokenManager;
 
     @Override
     public boolean supportsParameter(MethodParameter parameter) {
-        boolean hasUserIdAnnotation = parameter.hasParameterAnnotation(UserId.class);
+        boolean hasUserIdAnnotation = parameter.hasParameterAnnotation(LoginUserId.class);
         boolean isLongClass = Long.class.isAssignableFrom(parameter.getParameterType());
         return hasUserIdAnnotation && isLongClass;
     }

--- a/backend/src/main/java/org/youcancook/gobong/global/resolver/UserId.java
+++ b/backend/src/main/java/org/youcancook/gobong/global/resolver/UserId.java
@@ -1,0 +1,11 @@
+package org.youcancook.gobong.global.resolver;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.PARAMETER)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface UserId {
+}

--- a/backend/src/main/java/org/youcancook/gobong/global/resolver/UserIdArgumentResolver.java
+++ b/backend/src/main/java/org/youcancook/gobong/global/resolver/UserIdArgumentResolver.java
@@ -1,0 +1,36 @@
+package org.youcancook.gobong.global.resolver;
+
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
+import org.springframework.core.MethodParameter;
+import org.springframework.http.HttpHeaders;
+import org.springframework.stereotype.Component;
+import org.springframework.web.bind.support.WebDataBinderFactory;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.method.support.ModelAndViewContainer;
+import org.youcancook.gobong.global.util.token.TokenManager;
+
+@Component
+@RequiredArgsConstructor
+public class UserIdArgumentResolver implements HandlerMethodArgumentResolver {
+
+    private final TokenManager tokenManager;
+
+    @Override
+    public boolean supportsParameter(MethodParameter parameter) {
+        boolean hasUserIdAnnotation = parameter.hasParameterAnnotation(UserId.class);
+        boolean isLongClass = Long.class.isAssignableFrom(parameter.getParameterType());
+        return hasUserIdAnnotation && isLongClass;
+    }
+
+    @Override
+    public Object resolveArgument(MethodParameter parameter, ModelAndViewContainer mavContainer,
+                                  NativeWebRequest webRequest, WebDataBinderFactory binderFactory) {
+        HttpServletRequest request = (HttpServletRequest) webRequest.getNativeRequest();
+        String token = request.getHeader(HttpHeaders.AUTHORIZATION);
+        token = token.split(" ")[1];
+        return tokenManager.getUserIdFromAccessToken(token);
+    }
+
+}

--- a/backend/src/main/java/org/youcancook/gobong/global/util/token/exception/EmptyAuthorizationException.java
+++ b/backend/src/main/java/org/youcancook/gobong/global/util/token/exception/EmptyAuthorizationException.java
@@ -1,0 +1,10 @@
+package org.youcancook.gobong.global.util.token.exception;
+
+import org.youcancook.gobong.global.error.ErrorCode;
+import org.youcancook.gobong.global.error.exception.AuthenticationException;
+
+public class EmptyAuthorizationException extends AuthenticationException {
+    public EmptyAuthorizationException() {
+        super(ErrorCode.EMPTY_AUTHORIZATION);
+    }
+}

--- a/backend/src/main/java/org/youcancook/gobong/global/util/token/exception/ExpiredTokenException.java
+++ b/backend/src/main/java/org/youcancook/gobong/global/util/token/exception/ExpiredTokenException.java
@@ -1,0 +1,10 @@
+package org.youcancook.gobong.global.util.token.exception;
+
+import org.youcancook.gobong.global.error.ErrorCode;
+import org.youcancook.gobong.global.error.exception.AuthenticationException;
+
+public class ExpiredTokenException extends AuthenticationException {
+    public ExpiredTokenException() {
+        super(ErrorCode.EXPIRED_TOKEN);
+    }
+}

--- a/backend/src/main/java/org/youcancook/gobong/global/util/token/exception/InvalidTokenException.java
+++ b/backend/src/main/java/org/youcancook/gobong/global/util/token/exception/InvalidTokenException.java
@@ -1,0 +1,10 @@
+package org.youcancook.gobong.global.util.token.exception;
+
+import org.youcancook.gobong.global.error.ErrorCode;
+import org.youcancook.gobong.global.error.exception.AuthenticationException;
+
+public class InvalidTokenException extends AuthenticationException {
+    public InvalidTokenException() {
+        super(ErrorCode.INVALID_TOKEN);
+    }
+}

--- a/backend/src/main/java/org/youcancook/gobong/global/util/token/exception/InvalidTokenTypeException.java
+++ b/backend/src/main/java/org/youcancook/gobong/global/util/token/exception/InvalidTokenTypeException.java
@@ -1,0 +1,10 @@
+package org.youcancook.gobong.global.util.token.exception;
+
+import org.youcancook.gobong.global.error.ErrorCode;
+import org.youcancook.gobong.global.error.exception.AuthenticationException;
+
+public class InvalidTokenTypeException extends AuthenticationException {
+    public InvalidTokenTypeException() {
+        super(ErrorCode.INVALID_TOKEN_TYPE);
+    }
+}

--- a/backend/src/main/java/org/youcancook/gobong/global/util/token/exception/NotBearerGrantTypeException.java
+++ b/backend/src/main/java/org/youcancook/gobong/global/util/token/exception/NotBearerGrantTypeException.java
@@ -1,0 +1,10 @@
+package org.youcancook.gobong.global.util.token.exception;
+
+import org.youcancook.gobong.global.error.ErrorCode;
+import org.youcancook.gobong.global.error.exception.AuthenticationException;
+
+public class NotBearerGrantTypeException extends AuthenticationException {
+    public NotBearerGrantTypeException() {
+        super(ErrorCode.NOT_BEARER_GRANT_TYPE);
+    }
+}

--- a/backend/src/test/java/org/youcancook/gobong/global/util/token/TokenManagerTest.java
+++ b/backend/src/test/java/org/youcancook/gobong/global/util/token/TokenManagerTest.java
@@ -10,6 +10,8 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.test.util.ReflectionTestUtils;
 import org.youcancook.gobong.global.util.clock.ClockService;
+import org.youcancook.gobong.global.util.token.exception.InvalidTokenException;
+import org.youcancook.gobong.global.util.token.exception.InvalidTokenTypeException;
 
 import java.nio.charset.StandardCharsets;
 import java.text.ParseException;
@@ -17,6 +19,7 @@ import java.text.SimpleDateFormat;
 import java.util.Date;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
@@ -90,5 +93,77 @@ class TokenManagerTest {
 
         JwsHeader header = claimsJws.getHeader();
         assertThat(header.getType()).isEqualTo(Header.JWT_TYPE);
+    }
+
+    @Test
+    @DisplayName("AccessToken에서 userId 추출 성공")
+    void getUserIdFromAccessTokenSuccess() {
+        // given
+        TokenDto tokenDto = tokenManager.createTokenDto(1L);
+
+        // when
+        Long userId = tokenManager.getUserIdFromAccessToken(tokenDto.getAccessToken());
+
+        // then
+        assertThat(userId).isEqualTo(1L);
+    }
+
+    @Test
+    @DisplayName("AccessToken에서 userId 추출 실패 - 잘못된 토큰 타입")
+    void getUserIdFromAccessTokenFailByWrongTokenType() {
+        // given
+        TokenDto tokenDto = tokenManager.createTokenDto(1L);
+
+        // expect
+        assertThrows(InvalidTokenTypeException.class,
+                () -> tokenManager.getUserIdFromAccessToken(tokenDto.getRefreshToken()));
+    }
+
+    @Test
+    @DisplayName("AccessToken에서 userId 추출 실패 - 잘못된 토큰")
+    void getUserIdFromAccessTokenFailByWrongToken() {
+        // given
+        TokenDto tokenDto = tokenManager.createTokenDto(1L);
+        String wrongAccessToken = tokenDto.getAccessToken() + "wrong";
+
+        // expect
+        assertThrows(InvalidTokenException.class,
+                () -> tokenManager.getUserIdFromAccessToken(wrongAccessToken));
+    }
+
+    @Test
+    @DisplayName("RefreshToken에서 userId 추출 성공")
+    void getUserIdFromRefreshTokenSuccess() {
+        // given
+        TokenDto tokenDto = tokenManager.createTokenDto(1L);
+
+        // when
+        Long userId = tokenManager.getUserIdFromRefreshToken(tokenDto.getRefreshToken());
+
+        // then
+        assertThat(userId).isEqualTo(1L);
+    }
+
+    @Test
+    @DisplayName("RefreshToken에서 userId 추출 실패 - 잘못된 토큰 타입")
+    void getUserIdFromRefreshTokenFailByWrongTokenType() {
+        // given
+        TokenDto tokenDto = tokenManager.createTokenDto(1L);
+
+        // expect
+        assertThrows(InvalidTokenTypeException.class,
+                () -> tokenManager.getUserIdFromRefreshToken(tokenDto.getAccessToken()));
+    }
+
+    @Test
+    @DisplayName("RefreshToken에서 userId 추출 실패 - 잘못된 토큰")
+    void getUserIdFromRefreshTokenFailByWrongToken() {
+        // given
+        TokenDto tokenDto = tokenManager.createTokenDto(1L);
+        String wrongRefreshToken = tokenDto.getRefreshToken() + "wrong";
+
+        // expect
+        assertThrows(InvalidTokenException.class,
+                () -> tokenManager.getUserIdFromRefreshToken(wrongRefreshToken));
     }
 }


### PR DESCRIPTION
## 개요 🧾
Argument Resolver 생성

## 변경사항 🛠
request의 `AUTHORIZATION` 헤더에 담겨온 Access Token에서 추출한 `Long` 타입의 `userId`을 컨트롤러에서 파라미터로 받을 수 있습니다. 이때 `@UserId` 어노테이션을 붙여야 하고, 반드시 Long 타입으로 받아야 합니다.

```java
@GetMapping
public void test(@UserId Long userId) {
    System.out.println(userId);
}
```