### PR TITLE
feat: 회원가입 컨트롤러 생성

### DIFF
--- a/backend/src/main/java/org/youcancook/gobong/domain/user/controller/UserController.java
+++ b/backend/src/main/java/org/youcancook/gobong/domain/user/controller/UserController.java
@@ -6,18 +6,23 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import org.youcancook.gobong.domain.authentication.service.TemporaryTokenService;
+import org.youcancook.gobong.domain.user.dto.SignupDto;
 import org.youcancook.gobong.domain.user.dto.request.LoginRequest;
+import org.youcancook.gobong.domain.user.dto.request.SignupRequest;
 import org.youcancook.gobong.domain.user.dto.response.LoginResponse;
+import org.youcancook.gobong.domain.user.dto.response.SignupResponse;
 import org.youcancook.gobong.domain.user.dto.response.TemporaryTokenIssueResponse;
 import org.youcancook.gobong.domain.user.service.UserLoginService;
+import org.youcancook.gobong.domain.user.service.UserSignupService;
 
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("api/users")
 public class UserController {
 
-    private final UserLoginService userLoginService;
     private final TemporaryTokenService temporaryTokenService;
+    private final UserLoginService userLoginService;
+    private final UserSignupService userSignupService;
 
     @PostMapping("temporary-token")
     @ResponseStatus(HttpStatus.CREATED)
@@ -29,8 +34,17 @@ public class UserController {
 
     @PostMapping("login")
     public ResponseEntity<LoginResponse> login(@RequestBody @Valid LoginRequest request) {
-        temporaryTokenService.validateTemporaryToken(request.getTemporaryToken());
+        Long temporaryTokenId = temporaryTokenService.findTemporaryTokenId(request.getTemporaryToken());
         LoginResponse response = userLoginService.login(request.getProvider(), request.getOauthId());
+        temporaryTokenService.deleteTemporaryToken(temporaryTokenId);
+        return ResponseEntity.ok(response);
+    }
+
+    @PostMapping("signup")
+    public ResponseEntity<SignupResponse> signup(@RequestBody @Valid SignupRequest request) {
+        Long temporaryTokenId = temporaryTokenService.findTemporaryTokenId(request.getTemporaryToken());
+        SignupResponse response = userSignupService.signup(SignupDto.from(request));
+        temporaryTokenService.deleteTemporaryToken(temporaryTokenId);
         return ResponseEntity.ok(response);
     }
 }

--- a/backend/src/main/java/org/youcancook/gobong/domain/user/dto/SignupDto.java
+++ b/backend/src/main/java/org/youcancook/gobong/domain/user/dto/SignupDto.java
@@ -3,6 +3,7 @@ package org.youcancook.gobong.domain.user.dto;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
+import org.youcancook.gobong.domain.user.dto.request.SignupRequest;
 
 @Getter
 @Builder
@@ -13,4 +14,13 @@ public class SignupDto {
     private String oAuthProvider;
     private String oAuthId;
     private String profileImageURL;
+
+    public static SignupDto from(SignupRequest signupRequest) {
+        return SignupDto.builder()
+                .nickname(signupRequest.getNickname())
+                .oAuthProvider(signupRequest.getProvider())
+                .oAuthId(signupRequest.getOauthId())
+                .profileImageURL(signupRequest.getProfileImageURL())
+                .build();
+    }
 }

--- a/backend/src/main/java/org/youcancook/gobong/domain/user/dto/request/SignupRequest.java
+++ b/backend/src/main/java/org/youcancook/gobong/domain/user/dto/request/SignupRequest.java
@@ -4,13 +4,14 @@ import jakarta.validation.constraints.NotBlank;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.youcancook.gobong.global.validation.annotation.UserNickname;
 
 @Getter
 @NoArgsConstructor(access = lombok.AccessLevel.PRIVATE)
 @AllArgsConstructor
 public class SignupRequest {
 
-    @NotBlank(message = "nickname은 필수입니다.")
+    @UserNickname
     private String nickname;
 
     @NotBlank(message = "provider는 필수입니다.")

--- a/backend/src/main/java/org/youcancook/gobong/domain/user/entity/User.java
+++ b/backend/src/main/java/org/youcancook/gobong/domain/user/entity/User.java
@@ -21,7 +21,7 @@ public class User {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @Column(nullable = false)
+    @Column(nullable = false, unique = true)
     private String nickname;
 
     @Column(nullable = false, name = "oauth_id")

--- a/backend/src/main/java/org/youcancook/gobong/domain/user/service/UserSignupService.java
+++ b/backend/src/main/java/org/youcancook/gobong/domain/user/service/UserSignupService.java
@@ -23,9 +23,7 @@ public class UserSignupService {
 
     @Transactional
     public SignupResponse signup(SignupDto signupDto) {
-        if (isDuplicateNickname(signupDto.getNickname())) {
-            throw new DuplicationNicknameException();
-        }
+        validateDuplicateNickname(signupDto.getNickname());
 
         User user = createUser(signupDto);
         userRepository.save(user);
@@ -33,6 +31,16 @@ public class UserSignupService {
         TokenDto tokenDto = tokenManager.createTokenDto(user.getId());
         refreshTokenService.saveRefreshToken(user.getId(), tokenDto);
         return SignupResponse.from(tokenDto);
+    }
+
+    private void validateDuplicateNickname(String nickname) {
+        if (isDuplicateNickname(nickname)) {
+            throw new DuplicationNicknameException();
+        }
+    }
+
+    public boolean isDuplicateNickname(String nickname) {
+        return userRepository.existsByNickname(nickname);
     }
 
     private User createUser(SignupDto signupDto) {
@@ -43,9 +51,5 @@ public class UserSignupService {
                 .nickname(signupDto.getNickname())
                 .profileImageURL(signupDto.getProfileImageURL())
                 .build();
-    }
-
-    public boolean isDuplicateNickname(String nickname) {
-        return userRepository.existsByNickname(nickname);
     }
 }

--- a/backend/src/main/java/org/youcancook/gobong/global/validation/annotation/UserNickname.java
+++ b/backend/src/main/java/org/youcancook/gobong/global/validation/annotation/UserNickname.java
@@ -1,0 +1,24 @@
+package org.youcancook.gobong.global.validation.annotation;
+
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
+import org.youcancook.gobong.global.validation.validator.UserNicknameValidator;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Constraint(validatedBy = UserNicknameValidator.class)
+@Target({ElementType.METHOD, ElementType.FIELD})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface UserNickname {
+
+    String message() default "닉네임은 한글, 영어, 숫자로 10자 이내만 가능합니다.";
+
+    Class<?>[] groups() default {};
+
+    Class<? extends Payload>[] payload() default {};
+
+    String pattern() default "^[0-9a-zA-Z가-힣]{1,10}$";
+}

--- a/backend/src/main/java/org/youcancook/gobong/global/validation/validator/UserNicknameValidator.java
+++ b/backend/src/main/java/org/youcancook/gobong/global/validation/validator/UserNicknameValidator.java
@@ -1,0 +1,22 @@
+package org.youcancook.gobong.global.validation.validator;
+
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+import org.youcancook.gobong.global.validation.annotation.UserNickname;
+
+import java.util.regex.Pattern;
+
+public class UserNicknameValidator implements ConstraintValidator<UserNickname, String> {
+
+    private String pattern;
+
+    @Override
+    public void initialize(UserNickname constraintAnnotation) {
+        this.pattern = constraintAnnotation.pattern();
+    }
+
+    @Override
+    public boolean isValid(String value, ConstraintValidatorContext context) {
+        return Pattern.matches(pattern, value);
+    }
+}


### PR DESCRIPTION
## 개요 🧾
- TemporaryService의 메서드 분리
- 회원가입 컨트롤러 생성

## 변경사항 🛠
- TemporaryService에서 임시 토큰을 찾는 메서드와 삭제하는 메서드를 분리했습니다.
- 유저 닉네임을 검증하기 위해 validator를 생성하여 정규표현식으로 Pattern match를 수행합니다.
  - 정규표현식 : `^[0-9a-zA-Z가-힣]{1,10}$`
- 회원가입 API
  - URL : POST api/users/signup
  - Response 예시
  ```json
  {
    "grantType": "Bearer",
    "accessToken": "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJ1c2VySWQiOjQsInN1YiI6IkFDQ0VTUyIsImlzcyI6ImdvYm9uZy55b3VjYW5jb29rLm9yZyIsImlhdCI6MTY5MTM4ODk0MiwiZXhwIjoxNjkxMzk2MTQyfQ.a3g1bGNGJrcqExp_vfvkSIfM1p_ikhFion76q6YM_Zk",
    "refreshToken": "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJ1c2VySWQiOjQsInN1YiI6IlJFRlJFU0giLCJpc3MiOiJnb2JvbmcueW91Y2FuY29vay5vcmciLCJpYXQiOjE2OTEzODg5NDIsImV4cCI6MTY5MjU5ODU0Mn0.qkc1FT2zi5BUjOWvLaoEcghQ2Wnyz5qHLqx5XfZ4am4"
  }
  ```