### PR TITLE
feat: 레시피 삭제 기능 구현

### DIFF
--- a/backend/src/main/java/org/youcancook/gobong/domain/bookmarkrecipe/repository/BookmarkRecipeRepository.java
+++ b/backend/src/main/java/org/youcancook/gobong/domain/bookmarkrecipe/repository/BookmarkRecipeRepository.java
@@ -1,6 +1,8 @@
 package org.youcancook.gobong.domain.bookmarkrecipe.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
 import org.youcancook.gobong.domain.bookmarkrecipe.entity.BookmarkRecipe;
 
 import java.util.Optional;
@@ -9,5 +11,9 @@ public interface BookmarkRecipeRepository extends JpaRepository<BookmarkRecipe, 
     Optional<BookmarkRecipe> findByUserIdAndRecipeId(Long userId, Long recipeId);
 
     Boolean existsByUserIdAndRecipeId(Long userId, Long recipeId);
+
+    @Modifying
+    @Query("DELETE FROM BookmarkRecipe bm where bm.recipe.id =:recipeId")
+    void deleteAllByRecipeId(Long recipeId);
 
 }

--- a/backend/src/main/java/org/youcancook/gobong/domain/rating/repository/RatingRepository.java
+++ b/backend/src/main/java/org/youcancook/gobong/domain/rating/repository/RatingRepository.java
@@ -1,10 +1,16 @@
 package org.youcancook.gobong.domain.rating.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
 import org.youcancook.gobong.domain.rating.entity.Rating;
 
 import java.util.Optional;
 
 public interface RatingRepository extends JpaRepository<Rating, Long> {
     Optional<Rating> findByUserIdAndRecipeId(Long userId, Long recipeId);
+
+    @Modifying
+    @Query("DELETE FROM Rating r where r.recipe.id =:recipeId")
+    void deleteAllByRecipeId(Long recipeId);
 }

--- a/backend/src/main/java/org/youcancook/gobong/domain/recipe/service/RecipeService.java
+++ b/backend/src/main/java/org/youcancook/gobong/domain/recipe/service/RecipeService.java
@@ -3,6 +3,7 @@ package org.youcancook.gobong.domain.recipe.service;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.youcancook.gobong.domain.bookmarkrecipe.repository.BookmarkRecipeRepository;
 import org.youcancook.gobong.domain.rating.repository.RatingRepository;
 import org.youcancook.gobong.domain.recipe.dto.request.CreateRecipeRequest;
 import org.youcancook.gobong.domain.recipe.dto.request.UpdateRecipeRequest;
@@ -28,6 +29,7 @@ public class RecipeService {
     private final RecipeDetailRepository recipeDetailRepository;
     private final UserRepository userRepository;
     private final RatingRepository ratingRepository;
+    private final BookmarkRecipeRepository bookmarkRecipeRepository;
 
     @Transactional
     public CreateRecipeResponse createRecipe(Long userId, CreateRecipeRequest request){
@@ -58,6 +60,7 @@ public class RecipeService {
         Recipe recipe = recipeRepository.findById(recipeId).orElseThrow(RecipeNotFoundException::new);
         validateUserRecipe(user, recipe);
 
+        bookmarkRecipeRepository.deleteAllByRecipeId(recipeId);
         recipeDetailRepository.deleteAllByRecipeId(recipeId);
         ratingRepository.deleteAllByRecipeId(recipeId);
         recipeRepository.delete(recipe);

--- a/backend/src/main/java/org/youcancook/gobong/domain/recipe/service/RecipeService.java
+++ b/backend/src/main/java/org/youcancook/gobong/domain/recipe/service/RecipeService.java
@@ -3,6 +3,7 @@ package org.youcancook.gobong.domain.recipe.service;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.youcancook.gobong.domain.rating.repository.RatingRepository;
 import org.youcancook.gobong.domain.recipe.dto.request.CreateRecipeRequest;
 import org.youcancook.gobong.domain.recipe.dto.request.UpdateRecipeRequest;
 import org.youcancook.gobong.domain.recipe.dto.response.CreateRecipeResponse;
@@ -26,6 +27,7 @@ public class RecipeService {
     private final RecipeRepository recipeRepository;
     private final RecipeDetailRepository recipeDetailRepository;
     private final UserRepository userRepository;
+    private final RatingRepository ratingRepository;
 
     @Transactional
     public CreateRecipeResponse createRecipe(Long userId, CreateRecipeRequest request){
@@ -48,6 +50,17 @@ public class RecipeService {
         String parsedIngredients = String.join(",", request.getIngredients());
         recipe.updateProperties(request.getTitle(), request.getIntroduction(),
                 parsedIngredients, Difficulty.from(request.getDifficulty()), request.getThumbnailURL());
+    }
+
+    @Transactional
+    public void deleteRecipe(Long userId, Long recipeId){
+        User user = userRepository.findById(userId).orElseThrow(UserNotFoundException::new);
+        Recipe recipe = recipeRepository.findById(recipeId).orElseThrow(RecipeNotFoundException::new);
+        validateUserRecipe(user, recipe);
+
+        recipeDetailRepository.deleteAllByRecipeId(recipeId);
+        ratingRepository.deleteAllByRecipeId(recipeId);
+        recipeRepository.delete(recipe);
     }
 
     public void validateUserRecipe(User user, Recipe recipe){


### PR DESCRIPTION
## 개요 🧾
<!-- 이곳에 PR의 내용을 간단하게 작성해주세요. -->
레시피 삭제 기능을 구현했습니다. 레시피를 삭제하면, 해당 레시피와 연결된 단계별 레시피, 평점, 북마크가 삭제됩니다.
Cascade를 적용하지 않은 것은 다음 답변을 참고했는데, 어떻게 하는 게 나을지는 토의해도 괜찮을 것 같습니다
https://www.inflearn.com/questions/141700/%EB%8B%A8%EB%B0%A9%ED%96%A5-%EC%97%B0%EA%B4%80%EA%B4%80%EA%B3%84%EC%8B%9C-cascade-%EC%A7%88%EB%AC%B8%EC%9E%85%EB%8B%88%EB%8B%A4

## 주의사항 ⚠
<!-- 이곳에 리뷰어에게 할 말이나, 주의해야 하는 점에 대해서 작성해 주세요 -->
테스트하다가 알아낸 건데, `oAuthProvider`와 `oAuthId`가 같고 닉네임이 다른 경우 DB에 저장되는 걸 확인했는데, 따로 묶어서 constraint를 만들어야 할까 싶습니다,.