### PR TITLE
feat: 팔로우 서비스 및 컨트롤러 구현

### DIFF
--- a/backend/src/main/java/org/youcancook/gobong/domain/follow/controller/FollowController.java
+++ b/backend/src/main/java/org/youcancook/gobong/domain/follow/controller/FollowController.java
@@ -1,7 +1,6 @@
 package org.youcancook.gobong.domain.follow.controller;
 
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;

--- a/backend/src/main/java/org/youcancook/gobong/domain/follow/controller/FollowController.java
+++ b/backend/src/main/java/org/youcancook/gobong/domain/follow/controller/FollowController.java
@@ -1,0 +1,33 @@
+package org.youcancook.gobong.domain.follow.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import org.youcancook.gobong.domain.follow.service.FollowService;
+import org.youcancook.gobong.global.resolver.LoginUserId;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("api")
+public class FollowController {
+
+    private final FollowService followService;
+
+    @PostMapping("follow/{folloeeId}")
+    public ResponseEntity<Void> follow(@LoginUserId Long loginUserId,
+                                       @PathVariable Long folloeeId) {
+        followService.follow(loginUserId, folloeeId);
+        return ResponseEntity.ok().build();
+    }
+
+    @PostMapping("unfollow/{folloeeId}")
+    public ResponseEntity<Void> unfollow(@LoginUserId Long loginUserId,
+                                         @PathVariable Long folloeeId) {
+        followService.unfollow(loginUserId, folloeeId);
+        return ResponseEntity.ok().build();
+    }
+}

--- a/backend/src/main/java/org/youcancook/gobong/domain/follow/entity/Follow.java
+++ b/backend/src/main/java/org/youcancook/gobong/domain/follow/entity/Follow.java
@@ -21,12 +21,12 @@ public class Follow {
     private User follower;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "following_id")
-    private User following;
+    @JoinColumn(name = "followee_id")
+    private User followee;
 
     @Builder
-    public Follow(User follower, User following) {
+    public Follow(User follower, User followee) {
         this.follower = follower;
-        this.following = following;
+        this.followee = followee;
     }
 }

--- a/backend/src/main/java/org/youcancook/gobong/domain/follow/exception/AlreadyFollowException.java
+++ b/backend/src/main/java/org/youcancook/gobong/domain/follow/exception/AlreadyFollowException.java
@@ -1,0 +1,10 @@
+package org.youcancook.gobong.domain.follow.exception;
+
+import org.youcancook.gobong.global.error.ErrorCode;
+import org.youcancook.gobong.global.error.exception.IllegalException;
+
+public class AlreadyFollowException extends IllegalException {
+    public AlreadyFollowException() {
+        super(ErrorCode.ALREADY_FOLLOW);
+    }
+}

--- a/backend/src/main/java/org/youcancook/gobong/domain/follow/exception/AlreadyFollowingException.java
+++ b/backend/src/main/java/org/youcancook/gobong/domain/follow/exception/AlreadyFollowingException.java
@@ -3,8 +3,8 @@ package org.youcancook.gobong.domain.follow.exception;
 import org.youcancook.gobong.global.error.ErrorCode;
 import org.youcancook.gobong.global.error.exception.IllegalException;
 
-public class AlreadyFollowException extends IllegalException {
-    public AlreadyFollowException() {
-        super(ErrorCode.ALREADY_FOLLOW);
+public class AlreadyFollowingException extends IllegalException {
+    public AlreadyFollowingException() {
+        super(ErrorCode.ALREADY_FOLLOWING);
     }
 }

--- a/backend/src/main/java/org/youcancook/gobong/domain/follow/exception/NotFollowException.java
+++ b/backend/src/main/java/org/youcancook/gobong/domain/follow/exception/NotFollowException.java
@@ -1,0 +1,10 @@
+package org.youcancook.gobong.domain.follow.exception;
+
+import org.youcancook.gobong.global.error.ErrorCode;
+import org.youcancook.gobong.global.error.exception.IllegalException;
+
+public class NotFollowException extends IllegalException {
+    public NotFollowException() {
+        super(ErrorCode.NOT_FOLLOW);
+    }
+}

--- a/backend/src/main/java/org/youcancook/gobong/domain/follow/exception/NotFollowingException.java
+++ b/backend/src/main/java/org/youcancook/gobong/domain/follow/exception/NotFollowingException.java
@@ -3,8 +3,8 @@ package org.youcancook.gobong.domain.follow.exception;
 import org.youcancook.gobong.global.error.ErrorCode;
 import org.youcancook.gobong.global.error.exception.IllegalException;
 
-public class NotFollowException extends IllegalException {
-    public NotFollowException() {
-        super(ErrorCode.NOT_FOLLOW);
+public class NotFollowingException extends IllegalException {
+    public NotFollowingException() {
+        super(ErrorCode.NOT_FOLLOWING);
     }
 }

--- a/backend/src/main/java/org/youcancook/gobong/domain/follow/repository/FollowRepository.java
+++ b/backend/src/main/java/org/youcancook/gobong/domain/follow/repository/FollowRepository.java
@@ -2,6 +2,12 @@ package org.youcancook.gobong.domain.follow.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.youcancook.gobong.domain.follow.entity.Follow;
+import org.youcancook.gobong.domain.user.entity.User;
+
+import java.util.Optional;
 
 public interface FollowRepository extends JpaRepository<Follow, Long> {
+    boolean existsByFollowerAndFollowee(User follower, User followee);
+
+    Optional<Follow> findByFollowerAndFollowee(User follower, User followee);
 }

--- a/backend/src/main/java/org/youcancook/gobong/domain/follow/service/FollowService.java
+++ b/backend/src/main/java/org/youcancook/gobong/domain/follow/service/FollowService.java
@@ -1,0 +1,54 @@
+package org.youcancook.gobong.domain.follow.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.youcancook.gobong.domain.follow.entity.Follow;
+import org.youcancook.gobong.domain.follow.exception.AlreadyFollowException;
+import org.youcancook.gobong.domain.follow.exception.NotFollowException;
+import org.youcancook.gobong.domain.follow.repository.FollowRepository;
+import org.youcancook.gobong.domain.user.entity.User;
+import org.youcancook.gobong.domain.user.exception.UserNotFoundException;
+import org.youcancook.gobong.domain.user.repository.UserRepository;
+
+@Service
+@RequiredArgsConstructor
+public class FollowService {
+
+    private final UserRepository userRepository;
+    private final FollowRepository followRepository;
+
+    @Transactional
+    public void follow(Long followerId, Long followeeId) {
+        User follower = userRepository.findById(followerId)
+                .orElseThrow(UserNotFoundException::new);
+        User followee = userRepository.findById(followeeId)
+                .orElseThrow(UserNotFoundException::new);
+
+        validateAlreadyFollow(follower, followee);
+
+        Follow follow = Follow.builder()
+                .follower(follower)
+                .followee(followee)
+                .build();
+        followRepository.save(follow);
+    }
+
+    private void validateAlreadyFollow(User follower, User followee) {
+        if (followRepository.existsByFollowerAndFollowee(follower, followee)) {
+            throw new AlreadyFollowException();
+        }
+    }
+
+    @Transactional
+    public void unfollow(Long followerId, Long followeeId) {
+        User follower = userRepository.findById(followerId)
+                .orElseThrow(UserNotFoundException::new);
+        User followee = userRepository.findById(followeeId)
+                .orElseThrow(UserNotFoundException::new);
+
+        Follow follow = followRepository.findByFollowerAndFollowee(follower, followee)
+                .orElseThrow(NotFollowException::new);
+        followRepository.delete(follow);
+    }
+}

--- a/backend/src/main/java/org/youcancook/gobong/domain/follow/service/FollowService.java
+++ b/backend/src/main/java/org/youcancook/gobong/domain/follow/service/FollowService.java
@@ -4,8 +4,8 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.youcancook.gobong.domain.follow.entity.Follow;
-import org.youcancook.gobong.domain.follow.exception.AlreadyFollowException;
-import org.youcancook.gobong.domain.follow.exception.NotFollowException;
+import org.youcancook.gobong.domain.follow.exception.AlreadyFollowingException;
+import org.youcancook.gobong.domain.follow.exception.NotFollowingException;
 import org.youcancook.gobong.domain.follow.repository.FollowRepository;
 import org.youcancook.gobong.domain.user.entity.User;
 import org.youcancook.gobong.domain.user.exception.UserNotFoundException;
@@ -25,7 +25,7 @@ public class FollowService {
         User followee = userRepository.findById(followeeId)
                 .orElseThrow(UserNotFoundException::new);
 
-        validateAlreadyFollow(follower, followee);
+        validateAlreadyFollowing(follower, followee);
 
         Follow follow = Follow.builder()
                 .follower(follower)
@@ -34,9 +34,9 @@ public class FollowService {
         followRepository.save(follow);
     }
 
-    private void validateAlreadyFollow(User follower, User followee) {
+    private void validateAlreadyFollowing(User follower, User followee) {
         if (followRepository.existsByFollowerAndFollowee(follower, followee)) {
-            throw new AlreadyFollowException();
+            throw new AlreadyFollowingException();
         }
     }
 
@@ -48,7 +48,7 @@ public class FollowService {
                 .orElseThrow(UserNotFoundException::new);
 
         Follow follow = followRepository.findByFollowerAndFollowee(follower, followee)
-                .orElseThrow(NotFollowException::new);
+                .orElseThrow(NotFollowingException::new);
         followRepository.delete(follow);
     }
 }

--- a/backend/src/main/java/org/youcancook/gobong/domain/user/entity/User.java
+++ b/backend/src/main/java/org/youcancook/gobong/domain/user/entity/User.java
@@ -5,7 +5,6 @@ import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import org.youcancook.gobong.domain.follow.entity.Follow;
 import org.youcancook.gobong.domain.recipe.entity.Recipe;
 
 import java.util.ArrayList;
@@ -35,9 +34,6 @@ public class User {
 
     @OneToMany(mappedBy = "user")
     private List<Recipe> recipes = new ArrayList<>();
-
-    @OneToMany(mappedBy = "following")
-    private List<Follow> following = new ArrayList<>();
 
     @Builder
     public User(String nickname, String oAuthId, OAuthProvider oAuthProvider, String profileImageURL) {

--- a/backend/src/main/java/org/youcancook/gobong/global/error/ErrorCode.java
+++ b/backend/src/main/java/org/youcancook/gobong/global/error/ErrorCode.java
@@ -53,7 +53,12 @@ public enum ErrorCode {
     INVALID_DIFFICULTY_ARGUMENT(HttpStatus.BAD_REQUEST, "D003", "난이도는 '쉬워요', '보통이에요', '어려워요' 중 하나여야 합니다."),
 
     // S3 File upload
-    FAILED_TO_UPLOAD(HttpStatus.INTERNAL_SERVER_ERROR, "F001", "파일 업로드를 실패했습니다.");
+    FAILED_TO_UPLOAD(HttpStatus.INTERNAL_SERVER_ERROR, "F001", "파일 업로드를 실패했습니다."),
+
+    // Follow
+    ALREADY_FOLLOW(HttpStatus.BAD_REQUEST, "F101", "이미 팔로우한 사용자입니다."),
+    NOT_FOLLOW(HttpStatus.BAD_REQUEST, "F102", "팔로우하지 않은 사용자입니다."),
+    ;
 
     private final HttpStatus status;
     private final String code;

--- a/backend/src/main/java/org/youcancook/gobong/global/error/ErrorCode.java
+++ b/backend/src/main/java/org/youcancook/gobong/global/error/ErrorCode.java
@@ -56,8 +56,8 @@ public enum ErrorCode {
     FAILED_TO_UPLOAD(HttpStatus.INTERNAL_SERVER_ERROR, "F001", "파일 업로드를 실패했습니다."),
 
     // Follow
-    ALREADY_FOLLOW(HttpStatus.BAD_REQUEST, "F101", "이미 팔로우한 사용자입니다."),
-    NOT_FOLLOW(HttpStatus.BAD_REQUEST, "F102", "팔로우하지 않은 사용자입니다."),
+    ALREADY_FOLLOWING(HttpStatus.BAD_REQUEST, "F101", "이미 팔로우한 사용자입니다."),
+    NOT_FOLLOWING(HttpStatus.BAD_REQUEST, "F102", "팔로우하지 않은 사용자입니다."),
     ;
 
     private final HttpStatus status;

--- a/backend/src/test/java/org/youcancook/gobong/domain/follow/controller/FollowControllerTest.java
+++ b/backend/src/test/java/org/youcancook/gobong/domain/follow/controller/FollowControllerTest.java
@@ -82,8 +82,8 @@ class FollowControllerTest {
                         .header("Authorization", "Bearer " + accessToken)
                         .contentType(MediaType.APPLICATION_JSON))
                 .andExpect(status().isBadRequest())
-                .andExpect(jsonPath("$.code").value(ErrorCode.ALREADY_FOLLOW.getCode()))
-                .andExpect(jsonPath("$.message").value(ErrorCode.ALREADY_FOLLOW.getMessage()))
+                .andExpect(jsonPath("$.code").value(ErrorCode.ALREADY_FOLLOWING.getCode()))
+                .andExpect(jsonPath("$.message").value(ErrorCode.ALREADY_FOLLOWING.getMessage()))
                 .andDo(print());
     }
 
@@ -124,8 +124,8 @@ class FollowControllerTest {
                         .header("Authorization", "Bearer " + accessToken)
                         .contentType(MediaType.APPLICATION_JSON))
                 .andExpect(status().isBadRequest())
-                .andExpect(jsonPath("$.code").value(ErrorCode.NOT_FOLLOW.getCode()))
-                .andExpect(jsonPath("$.message").value(ErrorCode.NOT_FOLLOW.getMessage()))
+                .andExpect(jsonPath("$.code").value(ErrorCode.NOT_FOLLOWING.getCode()))
+                .andExpect(jsonPath("$.message").value(ErrorCode.NOT_FOLLOWING.getMessage()))
                 .andDo(print());
     }
 

--- a/backend/src/test/java/org/youcancook/gobong/domain/follow/controller/FollowControllerTest.java
+++ b/backend/src/test/java/org/youcancook/gobong/domain/follow/controller/FollowControllerTest.java
@@ -1,0 +1,142 @@
+package org.youcancook.gobong.domain.follow.controller;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.transaction.annotation.Transactional;
+import org.youcancook.gobong.domain.follow.entity.Follow;
+import org.youcancook.gobong.domain.follow.repository.FollowRepository;
+import org.youcancook.gobong.domain.user.entity.OAuthProvider;
+import org.youcancook.gobong.domain.user.entity.User;
+import org.youcancook.gobong.domain.user.repository.UserRepository;
+import org.youcancook.gobong.global.error.ErrorCode;
+import org.youcancook.gobong.global.util.token.TokenManager;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@AutoConfigureMockMvc
+@SpringBootTest
+@Transactional
+class FollowControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private FollowRepository followRepository;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private TokenManager tokenManager;
+
+    private static int testUserCount = 0;
+
+    @Test
+    @DisplayName("팔로우 성공")
+    void followSuccess() throws Exception {
+        // given
+        User loginUser = saveTestUser();
+        String accessToken = tokenManager.createTokenDto(loginUser.getId()).getAccessToken();
+        User followee = saveTestUser();
+
+        // when
+        mockMvc.perform(post("/api/follow/" + followee.getId())
+                        .header("Authorization", "Bearer " + accessToken)
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andDo(print());
+
+        // then
+        List<Follow> follows = followRepository.findAll();
+        assertThat(follows).hasSize(1);
+        assertThat(follows.get(0).getFollower()).isEqualTo(loginUser);
+        assertThat(follows.get(0).getFollowee()).isEqualTo(followee);
+    }
+
+    @Test
+    @DisplayName("팔로우 실패 - 이미 팔로잉된 유저")
+    void followFailByAlreadyFollowing() throws Exception {
+        // given
+        User loginUser = saveTestUser();
+        String accessToken = tokenManager.createTokenDto(loginUser.getId()).getAccessToken();
+        User followee = saveTestUser();
+        followRepository.save(Follow.builder()
+                .follower(loginUser)
+                .followee(followee)
+                .build());
+
+        // when
+        mockMvc.perform(post("/api/follow/" + followee.getId())
+                        .header("Authorization", "Bearer " + accessToken)
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value(ErrorCode.ALREADY_FOLLOW.getCode()))
+                .andExpect(jsonPath("$.message").value(ErrorCode.ALREADY_FOLLOW.getMessage()))
+                .andDo(print());
+    }
+
+    @Test
+    @DisplayName("언팔로우 성공")
+    void unfollowSuccess() throws Exception {
+        // given
+        User loginUser = saveTestUser();
+        String accessToken = tokenManager.createTokenDto(loginUser.getId()).getAccessToken();
+        User followee = saveTestUser();
+        followRepository.save(Follow.builder()
+                .follower(loginUser)
+                .followee(followee)
+                .build());
+
+        // when
+        mockMvc.perform(post("/api/unfollow/" + followee.getId())
+                        .header("Authorization", "Bearer " + accessToken)
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andDo(print());
+
+        // then
+        List<Follow> follows = followRepository.findAll();
+        assertThat(follows).hasSize(0);
+    }
+
+    @Test
+    @DisplayName("팔로우 실패 - 팔로우하지 않은 유저")
+    void unfollowFailByNotFollowing() throws Exception {
+        // given
+        User loginUser = saveTestUser();
+        String accessToken = tokenManager.createTokenDto(loginUser.getId()).getAccessToken();
+        User followee = saveTestUser();
+
+        // when
+        mockMvc.perform(post("/api/unfollow/" + followee.getId())
+                        .header("Authorization", "Bearer " + accessToken)
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value(ErrorCode.NOT_FOLLOW.getCode()))
+                .andExpect(jsonPath("$.message").value(ErrorCode.NOT_FOLLOW.getMessage()))
+                .andDo(print());
+    }
+
+    private User saveTestUser() {
+        testUserCount++;
+        User user = User.builder()
+                .oAuthId("12345678" + testUserCount)
+                .oAuthProvider((testUserCount % 2 == 0) ? OAuthProvider.KAKAO : OAuthProvider.GOOGLE)
+                .nickname("nickname" + testUserCount)
+                .profileImageURL("profileImageURL" + testUserCount)
+                .build();
+        return userRepository.save(user);
+    }
+}

--- a/backend/src/test/java/org/youcancook/gobong/domain/follow/service/FollowServiceTest.java
+++ b/backend/src/test/java/org/youcancook/gobong/domain/follow/service/FollowServiceTest.java
@@ -1,0 +1,140 @@
+package org.youcancook.gobong.domain.follow.service;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.youcancook.gobong.domain.follow.entity.Follow;
+import org.youcancook.gobong.domain.follow.exception.AlreadyFollowException;
+import org.youcancook.gobong.domain.follow.exception.NotFollowException;
+import org.youcancook.gobong.domain.follow.repository.FollowRepository;
+import org.youcancook.gobong.domain.user.entity.OAuthProvider;
+import org.youcancook.gobong.domain.user.entity.User;
+import org.youcancook.gobong.domain.user.repository.UserRepository;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class FollowServiceTest {
+
+    @InjectMocks
+    private FollowService followService;
+
+    @Mock
+    private UserRepository userRepository;
+
+    @Mock
+    private FollowRepository followRepository;
+
+    @Test
+    @DisplayName("팔로우 성공")
+    void followSuccess() {
+        // given
+        User follower = createTestUser(1L);
+        User followee = createTestUser(2L);
+
+        when(userRepository.findById(follower.getId()))
+                .thenReturn(Optional.of(follower));
+        when(userRepository.findById(followee.getId()))
+                .thenReturn(Optional.of(followee));
+        when(followRepository.existsByFollowerAndFollowee(follower, followee))
+                .thenReturn(false);
+        when(followRepository.save(any(Follow.class)))
+                .thenReturn(new Follow(follower, followee));
+
+        // when
+        followService.follow(follower.getId(), followee.getId());
+
+        // then
+        ArgumentCaptor<Follow> argument = ArgumentCaptor.forClass(Follow.class);
+        verify(followRepository, times(1)).save(argument.capture());
+        assertThat(argument.getValue().getFollower()).isEqualTo(follower);
+        assertThat(argument.getValue().getFollowee()).isEqualTo(followee);
+    }
+
+    @Test
+    @DisplayName("팔로우 실패 - 이미 팔로우한 유저")
+    void followFailByAlreadyFollowing() {
+        // given
+        User follower = createTestUser(1L);
+        User followee = createTestUser(2L);
+
+        when(userRepository.findById(follower.getId()))
+                .thenReturn(Optional.of(follower));
+        when(userRepository.findById(followee.getId()))
+                .thenReturn(Optional.of(followee));
+        when(followRepository.existsByFollowerAndFollowee(follower, followee))
+                .thenReturn(true);
+
+        // when
+        assertThrows(AlreadyFollowException.class, () -> {
+            followService.follow(follower.getId(), followee.getId());
+        });
+    }
+
+    @Test
+    @DisplayName("언팔로우 성공")
+    void unfollowSuccess() {
+        // given
+        User follower = createTestUser(1L);
+        User followee = createTestUser(2L);
+
+        when(userRepository.findById(follower.getId()))
+                .thenReturn(Optional.of(follower));
+        when(userRepository.findById(followee.getId()))
+                .thenReturn(Optional.of(followee));
+
+        Follow follow = new Follow(follower, followee);
+        when(followRepository.findByFollowerAndFollowee(follower, followee))
+                .thenReturn(Optional.of(follow));
+        doNothing().when(followRepository).delete(follow);
+
+        // when
+        followService.unfollow(follower.getId(), followee.getId());
+
+        // then
+        ArgumentCaptor<Follow> argument = ArgumentCaptor.forClass(Follow.class);
+        verify(followRepository, times(1)).delete(argument.capture());
+        assertThat(argument.getValue().getFollower()).isEqualTo(follower);
+        assertThat(argument.getValue().getFollowee()).isEqualTo(followee);
+    }
+
+    @Test
+    @DisplayName("언팔로우 실패 - 팔로우하지 않은 유저")
+    void unfollowFailByNotFollowing() {
+        // given
+        User follower = createTestUser(1L);
+        User followee = createTestUser(2L);
+
+        when(userRepository.findById(follower.getId()))
+                .thenReturn(Optional.of(follower));
+        when(userRepository.findById(followee.getId()))
+                .thenReturn(Optional.of(followee));
+        when(followRepository.findByFollowerAndFollowee(follower, followee))
+                .thenReturn(Optional.empty());
+
+        // when
+        assertThrows(NotFollowException.class, () -> {
+            followService.unfollow(follower.getId(), followee.getId());
+        });
+    }
+
+    private User createTestUser(Long userId) {
+        User user = User.builder()
+                .nickname("nickname" + userId)
+                .oAuthProvider(OAuthProvider.KAKAO)
+                .oAuthId("oauthid" + userId)
+                .build();
+        ReflectionTestUtils.setField(user, "id", userId);
+        return user;
+    }
+}

--- a/backend/src/test/java/org/youcancook/gobong/domain/follow/service/FollowServiceTest.java
+++ b/backend/src/test/java/org/youcancook/gobong/domain/follow/service/FollowServiceTest.java
@@ -76,9 +76,7 @@ class FollowServiceTest {
                 .thenReturn(true);
 
         // when
-        assertThrows(AlreadyFollowException.class, () -> {
-            followService.follow(follower.getId(), followee.getId());
-        });
+        assertThrows(AlreadyFollowException.class, () -> followService.follow(follower.getId(), followee.getId()));
     }
 
     @Test
@@ -123,9 +121,7 @@ class FollowServiceTest {
                 .thenReturn(Optional.empty());
 
         // when
-        assertThrows(NotFollowException.class, () -> {
-            followService.unfollow(follower.getId(), followee.getId());
-        });
+        assertThrows(NotFollowException.class, () -> followService.unfollow(follower.getId(), followee.getId()));
     }
 
     private User createTestUser(Long userId) {

--- a/backend/src/test/java/org/youcancook/gobong/domain/follow/service/FollowServiceTest.java
+++ b/backend/src/test/java/org/youcancook/gobong/domain/follow/service/FollowServiceTest.java
@@ -9,8 +9,8 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.test.util.ReflectionTestUtils;
 import org.youcancook.gobong.domain.follow.entity.Follow;
-import org.youcancook.gobong.domain.follow.exception.AlreadyFollowException;
-import org.youcancook.gobong.domain.follow.exception.NotFollowException;
+import org.youcancook.gobong.domain.follow.exception.AlreadyFollowingException;
+import org.youcancook.gobong.domain.follow.exception.NotFollowingException;
 import org.youcancook.gobong.domain.follow.repository.FollowRepository;
 import org.youcancook.gobong.domain.user.entity.OAuthProvider;
 import org.youcancook.gobong.domain.user.entity.User;
@@ -76,7 +76,7 @@ class FollowServiceTest {
                 .thenReturn(true);
 
         // when
-        assertThrows(AlreadyFollowException.class, () -> followService.follow(follower.getId(), followee.getId()));
+        assertThrows(AlreadyFollowingException.class, () -> followService.follow(follower.getId(), followee.getId()));
     }
 
     @Test
@@ -121,7 +121,7 @@ class FollowServiceTest {
                 .thenReturn(Optional.empty());
 
         // when
-        assertThrows(NotFollowException.class, () -> followService.unfollow(follower.getId(), followee.getId()));
+        assertThrows(NotFollowingException.class, () -> followService.unfollow(follower.getId(), followee.getId()));
     }
 
     private User createTestUser(Long userId) {


### PR DESCRIPTION
## 개요 🧾
follow, unfollow 기능을 수행하는 api 생성

## 변경사항 🛠
- url 방식은 [트위터 api](https://developer.twitter.com/en/docs/twitter-api/v1/accounts-and-users/follow-search-get-users/overview)를 참고했습니다.
- User entity에서 팔로잉을 관리하는 리스트(oneToMany)를 삭제했습니다.