### PR TITLE
fix: 인수 테스트 격리에서 발생하는 테스트 실패 해결

### DIFF
--- a/backend/src/main/java/org/youcancook/gobong/domain/authentication/entity/RefreshToken.java
+++ b/backend/src/main/java/org/youcancook/gobong/domain/authentication/entity/RefreshToken.java
@@ -14,11 +14,7 @@ import java.util.Date;
 @Table(name = "refresh_token")
 public class RefreshToken {
 
-    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
-    @Column(name = "refresh_token_id")
-    private Long id;
-
-    @Column(unique = true)
+    @Id
     private Long userId;
 
     private String refreshToken;

--- a/backend/src/main/java/org/youcancook/gobong/domain/authentication/entity/RefreshToken.java
+++ b/backend/src/main/java/org/youcancook/gobong/domain/authentication/entity/RefreshToken.java
@@ -1,7 +1,6 @@
 package org.youcancook.gobong.domain.authentication.entity;
 
-import jakarta.persistence.Entity;
-import jakarta.persistence.Id;
+import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -12,9 +11,14 @@ import java.util.Date;
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "refresh_token")
 public class RefreshToken {
 
-    @Id
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "refresh_token_id")
+    private Long id;
+
+    @Column(unique = true)
     private Long userId;
 
     private String refreshToken;

--- a/backend/src/main/java/org/youcancook/gobong/domain/authentication/entity/TemporaryToken.java
+++ b/backend/src/main/java/org/youcancook/gobong/domain/authentication/entity/TemporaryToken.java
@@ -1,9 +1,6 @@
 package org.youcancook.gobong.domain.authentication.entity;
 
-import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
+import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -13,10 +10,12 @@ import java.time.LocalDateTime;
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "temporary_token")
 public class TemporaryToken {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "temporary_token_id")
     private Long id;
 
     private String token;

--- a/backend/src/main/java/org/youcancook/gobong/domain/bookmarkrecipe/entity/BookmarkRecipe.java
+++ b/backend/src/main/java/org/youcancook/gobong/domain/bookmarkrecipe/entity/BookmarkRecipe.java
@@ -11,13 +11,15 @@ import org.youcancook.gobong.domain.user.entity.User;
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@Table(uniqueConstraints = {
+@Table(name = "bookmark_recipe",
+        uniqueConstraints = {
         @UniqueConstraint(columnNames = {"user_id", "recipe_id"})
 })
 public class BookmarkRecipe {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "bookmark_recipe_id")
     private Long id;
 
     @ManyToOne(fetch = FetchType.LAZY)

--- a/backend/src/main/java/org/youcancook/gobong/domain/follow/entity/Follow.java
+++ b/backend/src/main/java/org/youcancook/gobong/domain/follow/entity/Follow.java
@@ -10,10 +10,12 @@ import org.youcancook.gobong.domain.user.entity.User;
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "follow")
 public class Follow {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "follow_id")
     private Long id;
 
     @ManyToOne(fetch = FetchType.LAZY)

--- a/backend/src/main/java/org/youcancook/gobong/domain/rating/entity/Rating.java
+++ b/backend/src/main/java/org/youcancook/gobong/domain/rating/entity/Rating.java
@@ -12,7 +12,8 @@ import org.youcancook.gobong.domain.user.entity.User;
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@Table(uniqueConstraints = {
+@Table(name = "rating",
+        uniqueConstraints = {
         @UniqueConstraint(columnNames = {"user_id", "recipe_id"})
 })
 public class Rating {
@@ -22,6 +23,7 @@ public class Rating {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "rating_id")
     private Long id;
 
     @ManyToOne(fetch = FetchType.LAZY)

--- a/backend/src/main/java/org/youcancook/gobong/domain/recipe/entity/Recipe.java
+++ b/backend/src/main/java/org/youcancook/gobong/domain/recipe/entity/Recipe.java
@@ -15,9 +15,12 @@ import java.util.List;
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "recipe")
 public class Recipe extends BaseTime {
+
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "recipe_id")
     private Long id;
 
     @ManyToOne(fetch = FetchType.LAZY)

--- a/backend/src/main/java/org/youcancook/gobong/domain/recipedetail/entity/RecipeDetail.java
+++ b/backend/src/main/java/org/youcancook/gobong/domain/recipedetail/entity/RecipeDetail.java
@@ -10,9 +10,12 @@ import org.youcancook.gobong.domain.recipe.entity.Recipe;
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "recipe_detail")
 public class RecipeDetail {
+
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "recipe_detail_id")
     private Long id;
 
     private String content;

--- a/backend/src/main/java/org/youcancook/gobong/domain/user/dto/response/TemporaryTokenIssueResponse.java
+++ b/backend/src/main/java/org/youcancook/gobong/domain/user/dto/response/TemporaryTokenIssueResponse.java
@@ -1,10 +1,13 @@
 package org.youcancook.gobong.domain.user.dto.response;
 
+import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Getter
 @AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class TemporaryTokenIssueResponse {
     private String temporaryToken;
 }

--- a/backend/src/main/java/org/youcancook/gobong/domain/user/entity/User.java
+++ b/backend/src/main/java/org/youcancook/gobong/domain/user/entity/User.java
@@ -13,12 +13,13 @@ import java.util.List;
 
 @Entity
 @Getter
-@Table(name = "users")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "user")
 public class User {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "user_id")
     private Long id;
 
     @Column(nullable = false, unique = true)

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -5,7 +5,7 @@ spring:
       path: /h2-console
 
   datasource:
-    url: jdbc:h2:mem:test
+    url: jdbc:h2:mem:test;NON_KEYWORDS=USER
     username: sa
     password:
     driver-class-name: org.h2.Driver

--- a/backend/src/test/java/org/youcancook/gobong/domain/bookmarkrecipe/service/BookmarkRecipeServiceTest.java
+++ b/backend/src/test/java/org/youcancook/gobong/domain/bookmarkrecipe/service/BookmarkRecipeServiceTest.java
@@ -5,7 +5,6 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
 import org.youcancook.gobong.domain.bookmarkrecipe.entity.BookmarkRecipe;
 import org.youcancook.gobong.domain.bookmarkrecipe.exception.AlreadyBookmarkedRecipeException;
 import org.youcancook.gobong.domain.bookmarkrecipe.exception.BookmarkRecipeNotFoundException;
@@ -16,12 +15,13 @@ import org.youcancook.gobong.domain.recipe.repository.RecipeRepository;
 import org.youcancook.gobong.domain.user.entity.OAuthProvider;
 import org.youcancook.gobong.domain.user.entity.User;
 import org.youcancook.gobong.domain.user.repository.UserRepository;
+import org.youcancook.gobong.global.util.service.ServiceTest;
 
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
-@SpringBootTest
+@ServiceTest
 class BookmarkRecipeServiceTest {
     @Autowired
     UserRepository userRepository;

--- a/backend/src/test/java/org/youcancook/gobong/domain/rating/service/RatingServiceTest.java
+++ b/backend/src/test/java/org/youcancook/gobong/domain/rating/service/RatingServiceTest.java
@@ -5,7 +5,6 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
 import org.youcancook.gobong.domain.rating.entity.Rating;
 import org.youcancook.gobong.domain.rating.repository.RatingRepository;
 import org.youcancook.gobong.domain.recipe.entity.Difficulty;
@@ -14,11 +13,12 @@ import org.youcancook.gobong.domain.recipe.repository.RecipeRepository;
 import org.youcancook.gobong.domain.user.entity.OAuthProvider;
 import org.youcancook.gobong.domain.user.entity.User;
 import org.youcancook.gobong.domain.user.repository.UserRepository;
+import org.youcancook.gobong.global.util.service.ServiceTest;
 
 import java.util.Optional;
 
 
-@SpringBootTest
+@ServiceTest
 class RatingServiceTest {
     @Autowired
     RatingService ratingService;

--- a/backend/src/test/java/org/youcancook/gobong/domain/recipe/service/RecipeServiceTest.java
+++ b/backend/src/test/java/org/youcancook/gobong/domain/recipe/service/RecipeServiceTest.java
@@ -4,7 +4,6 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
 import org.youcancook.gobong.domain.bookmarkrecipe.entity.BookmarkRecipe;
 import org.youcancook.gobong.domain.bookmarkrecipe.repository.BookmarkRecipeRepository;
 import org.youcancook.gobong.domain.rating.entity.Rating;
@@ -21,6 +20,7 @@ import org.youcancook.gobong.domain.recipedetail.repository.RecipeDetailReposito
 import org.youcancook.gobong.domain.user.entity.OAuthProvider;
 import org.youcancook.gobong.domain.user.entity.User;
 import org.youcancook.gobong.domain.user.repository.UserRepository;
+import org.youcancook.gobong.global.util.service.ServiceTest;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -29,7 +29,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
-@SpringBootTest
+@ServiceTest
 class RecipeServiceTest {
     @Autowired
     RecipeService recipeService;

--- a/backend/src/test/java/org/youcancook/gobong/domain/recipedetail/service/RecipeDetailServiceTest.java
+++ b/backend/src/test/java/org/youcancook/gobong/domain/recipedetail/service/RecipeDetailServiceTest.java
@@ -4,7 +4,6 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.transaction.annotation.Transactional;
 import org.youcancook.gobong.domain.recipe.entity.Cookware;
 import org.youcancook.gobong.domain.recipe.entity.Difficulty;
@@ -17,13 +16,14 @@ import org.youcancook.gobong.domain.recipedetail.repository.RecipeDetailReposito
 import org.youcancook.gobong.domain.user.entity.OAuthProvider;
 import org.youcancook.gobong.domain.user.entity.User;
 import org.youcancook.gobong.domain.user.repository.UserRepository;
+import org.youcancook.gobong.global.util.service.ServiceTest;
 
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
-@SpringBootTest
+@ServiceTest
 class RecipeDetailServiceTest {
 
     @Autowired

--- a/backend/src/test/java/org/youcancook/gobong/global/util/acceptance/AcceptanceTest.java
+++ b/backend/src/test/java/org/youcancook/gobong/global/util/acceptance/AcceptanceTest.java
@@ -2,27 +2,20 @@ package org.youcancook.gobong.global.util.acceptance;
 
 import io.restassured.RestAssured;
 import org.junit.jupiter.api.BeforeEach;
-import org.springframework.beans.factory.annotation.Autowired;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.web.server.LocalServerPort;
-import org.youcancook.gobong.global.util.service.DatabaseCleaner;
-
-import static io.restassured.RestAssured.UNDEFINED_PORT;
+import org.youcancook.gobong.global.util.service.DatabaseCleanupExtension;
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@ExtendWith(DatabaseCleanupExtension.class)
 public class AcceptanceTest {
-
-    @Autowired
-    private DatabaseCleaner databaseCleaner;
 
     @LocalServerPort
     public int port;
+
     @BeforeEach
     void setUp(){
-        if (RestAssured.port == UNDEFINED_PORT){
-            RestAssured.port = port;
-            databaseCleaner.afterPropertiesSet();
-        }
-        databaseCleaner.execute();
+        RestAssured.port = port;
     }
 }

--- a/backend/src/test/java/org/youcancook/gobong/global/util/acceptance/AcceptanceTest.java
+++ b/backend/src/test/java/org/youcancook/gobong/global/util/acceptance/AcceptanceTest.java
@@ -5,16 +5,15 @@ import org.junit.jupiter.api.BeforeEach;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.web.server.LocalServerPort;
-import org.springframework.test.context.ActiveProfiles;
+import org.youcancook.gobong.global.util.service.DatabaseCleaner;
 
 import static io.restassured.RestAssured.UNDEFINED_PORT;
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
-@ActiveProfiles("acceptance")
 public class AcceptanceTest {
 
     @Autowired
-    private DatabaseCleanup databaseCleanup;
+    private DatabaseCleaner databaseCleaner;
 
     @LocalServerPort
     public int port;
@@ -22,8 +21,8 @@ public class AcceptanceTest {
     void setUp(){
         if (RestAssured.port == UNDEFINED_PORT){
             RestAssured.port = port;
-            databaseCleanup.afterPropertiesSet();
+            databaseCleaner.afterPropertiesSet();
         }
-        databaseCleanup.execute();
+        databaseCleaner.execute();
     }
 }

--- a/backend/src/test/java/org/youcancook/gobong/global/util/service/DatabaseCleaner.java
+++ b/backend/src/test/java/org/youcancook/gobong/global/util/service/DatabaseCleaner.java
@@ -1,19 +1,17 @@
-package org.youcancook.gobong.global.util.acceptance;
+package org.youcancook.gobong.global.util.service;
 
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.PersistenceContext;
 import jakarta.persistence.Table;
 import jakarta.persistence.metamodel.Type;
 import org.springframework.beans.factory.InitializingBean;
-import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 
 @Component
-@Profile("acceptance")
-public class DatabaseCleanup implements InitializingBean {
+public class DatabaseCleaner implements InitializingBean {
 
     @PersistenceContext
     private EntityManager entityManager;
@@ -35,7 +33,9 @@ public class DatabaseCleanup implements InitializingBean {
         entityManager.createNativeQuery("SET REFERENTIAL_INTEGRITY FALSE").executeUpdate();
         for(String tableName : tableNames){
             entityManager.createNativeQuery("TRUNCATE TABLE " + tableName).executeUpdate();
-            entityManager.createNativeQuery("ALTER TABLE " + tableName + " ALTER COLUMN " + tableName + "_id RESTART WITH 1").executeUpdate();
+            if (!tableName.contains("refresh_token")){
+                entityManager.createNativeQuery("ALTER TABLE " + tableName + " ALTER COLUMN " + tableName + "_id RESTART WITH 1").executeUpdate();
+            }
         }
         entityManager.createNativeQuery("SET REFERENTIAL_INTEGRITY TRUE").executeUpdate();
     }

--- a/backend/src/test/java/org/youcancook/gobong/global/util/service/DatabaseCleanupExtension.java
+++ b/backend/src/test/java/org/youcancook/gobong/global/util/service/DatabaseCleanupExtension.java
@@ -1,0 +1,17 @@
+package org.youcancook.gobong.global.util.service;
+
+import org.junit.jupiter.api.extension.BeforeEachCallback;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+public class DatabaseCleanupExtension implements BeforeEachCallback {
+    @Override
+    public void beforeEach(ExtensionContext context) throws Exception {
+        DatabaseCleaner databaseCleaner = getDatabaseCleaner(context);
+        databaseCleaner.execute();
+    }
+
+    private DatabaseCleaner getDatabaseCleaner(ExtensionContext context){
+        return SpringExtension.getApplicationContext(context).getBean(DatabaseCleaner.class);
+    }
+}

--- a/backend/src/test/java/org/youcancook/gobong/global/util/service/ServiceTest.java
+++ b/backend/src/test/java/org/youcancook/gobong/global/util/service/ServiceTest.java
@@ -1,0 +1,16 @@
+package org.youcancook.gobong.global.util.service;
+
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.TYPE)
+@Retention(RetentionPolicy.RUNTIME)
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@ExtendWith(DatabaseCleanupExtension.class)
+public @interface ServiceTest {
+}


### PR DESCRIPTION
## 개요 🧾
<!-- 이곳에 PR의 내용을 간단하게 작성해주세요. -->
close #26 

1. H2 예약어 `USER`로 인해, 현재 유저 테이블명이 `users`로 설정돼 있었습니다.
2. 인수 테스트 격리를 위해 만들어둔 템플릿에서는 `@Table` 어노테이션이 붙어있는 클래스를 긁어온 뒤, `해당 테이블의 이름 + _id`의 형식으로 테이블을 Truncate하고, `id`를 1부터 시작하도록 재정의합니다.

- 이 때, TemporaryToken의 id가 IDENTITY가 아니라서 초기화가 불가능했고,
- `@Table` 내 name과 id의 column을 미리 만들어두지 않아 내부에서 값이 적용되지 않는 현상이 발생했습니다.
- Users의 경우, 컬럼 이름을 `users_id`로까지 할 필요는 없다고 판단했습니다.


## 변경사항 🛠
<!-- 이곳에 코드 변경 사항이나 추가된 사항에 대해서 작성해주세요. -->

H2 예약어에 해당하는 USER를 예약어 해제 처리했습니다.
각 Entity에 Table명을 명시했고, 추가로 Id의 컬럼명도 명시했습니다. 이건 나중에 모든 필드에 대해서 진행해도 좋을 것 같습니다.
TemporaryToken에 자체 id 컬럼을 추가했습니다.

## 주의사항 ⚠
<!-- 이곳에 리뷰어에게 할 말이나, 주의해야 하는 점에 대해서 작성해 주세요 -->
모든 테스트를 돌려보고 PR을 올립니다만,, 꼼꼼히 위 내용 확인해주시면 감사하겠습니다~!