### PR TITLE
fix: 회원가입 시에 oauthId와 provider가 이미 존재한 데이터인지 확인하는 검증 추가

### DIFF
--- a/backend/src/main/java/org/youcancook/gobong/domain/user/dto/SignupDto.java
+++ b/backend/src/main/java/org/youcancook/gobong/domain/user/dto/SignupDto.java
@@ -4,6 +4,7 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import org.youcancook.gobong.domain.user.dto.request.SignupRequest;
+import org.youcancook.gobong.domain.user.entity.OAuthProvider;
 
 @Getter
 @Builder
@@ -11,14 +12,15 @@ import org.youcancook.gobong.domain.user.dto.request.SignupRequest;
 public class SignupDto {
 
     private String nickname;
-    private String oAuthProvider;
+    private OAuthProvider oAuthProvider;
     private String oAuthId;
     private String profileImageURL;
 
     public static SignupDto from(SignupRequest signupRequest) {
+        OAuthProvider oAuthProvider = OAuthProvider.from(signupRequest.getProvider());
         return SignupDto.builder()
                 .nickname(signupRequest.getNickname())
-                .oAuthProvider(signupRequest.getProvider())
+                .oAuthProvider(oAuthProvider)
                 .oAuthId(signupRequest.getOauthId())
                 .profileImageURL(signupRequest.getProfileImageURL())
                 .build();

--- a/backend/src/main/java/org/youcancook/gobong/domain/user/entity/User.java
+++ b/backend/src/main/java/org/youcancook/gobong/domain/user/entity/User.java
@@ -13,7 +13,10 @@ import java.util.List;
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@Table(name = "user")
+@Table(name = "user",
+        uniqueConstraints = {
+                @UniqueConstraint(columnNames = {"oauth_id", "oauth_provider"})
+        })
 public class User {
 
     @Id

--- a/backend/src/main/java/org/youcancook/gobong/domain/user/exception/AlreadyExistUserException.java
+++ b/backend/src/main/java/org/youcancook/gobong/domain/user/exception/AlreadyExistUserException.java
@@ -1,0 +1,10 @@
+package org.youcancook.gobong.domain.user.exception;
+
+import org.youcancook.gobong.global.error.ErrorCode;
+import org.youcancook.gobong.global.error.exception.IllegalException;
+
+public class AlreadyExistUserException extends IllegalException {
+    public AlreadyExistUserException() {
+        super(ErrorCode.ALREADY_EXIST_USER);
+    }
+}

--- a/backend/src/main/java/org/youcancook/gobong/domain/user/exception/UserAlreadyExistsException.java
+++ b/backend/src/main/java/org/youcancook/gobong/domain/user/exception/UserAlreadyExistsException.java
@@ -3,8 +3,8 @@ package org.youcancook.gobong.domain.user.exception;
 import org.youcancook.gobong.global.error.ErrorCode;
 import org.youcancook.gobong.global.error.exception.IllegalException;
 
-public class AlreadyExistUserException extends IllegalException {
-    public AlreadyExistUserException() {
-        super(ErrorCode.ALREADY_EXIST_USER);
+public class UserAlreadyExistsException extends IllegalException {
+    public UserAlreadyExistsException() {
+        super(ErrorCode.USER_ALREADY_EXISTS);
     }
 }

--- a/backend/src/main/java/org/youcancook/gobong/domain/user/repository/UserRepository.java
+++ b/backend/src/main/java/org/youcancook/gobong/domain/user/repository/UserRepository.java
@@ -12,4 +12,7 @@ public interface UserRepository extends JpaRepository<User, Long> {
     Optional<User> findByOAuthProviderAndOAuthId(OAuthProvider oAuthProvider, String oAuthId);
 
     boolean existsByNickname(String nickname);
+
+    @Query("SELECT exists(SELECT 1 FROM User u WHERE u.oAuthProvider =:oAuthProvider AND u.oAuthId =:oAuthId)")
+    boolean existsByOAuthProviderAndOAuthId(OAuthProvider oAuthProvider, String oAuthId);
 }

--- a/backend/src/main/java/org/youcancook/gobong/domain/user/service/UserSignupService.java
+++ b/backend/src/main/java/org/youcancook/gobong/domain/user/service/UserSignupService.java
@@ -25,7 +25,7 @@ public class UserSignupService {
     @Transactional
     public SignupResponse signup(SignupDto signupDto) {
         validateDuplicateNickname(signupDto.getNickname());
-        validateExistUser(signupDto.getOAuthId(), signupDto.getOAuthProvider());
+        validateExistUser(signupDto.getOAuthProvider(), signupDto.getOAuthId());
 
         User user = createUser(signupDto);
         userRepository.save(user);
@@ -45,7 +45,7 @@ public class UserSignupService {
         return userRepository.existsByNickname(nickname);
     }
 
-    private void validateExistUser(String oAuthId, OAuthProvider oAuthProvider) {
+    private void validateExistUser(OAuthProvider oAuthProvider, String oAuthId) {
         if (userRepository.existsByOAuthProviderAndOAuthId(oAuthProvider, oAuthId)) {
             throw new AlreadyExistUserException();
         }

--- a/backend/src/main/java/org/youcancook/gobong/domain/user/service/UserSignupService.java
+++ b/backend/src/main/java/org/youcancook/gobong/domain/user/service/UserSignupService.java
@@ -8,7 +8,7 @@ import org.youcancook.gobong.domain.user.dto.SignupDto;
 import org.youcancook.gobong.domain.user.dto.response.SignupResponse;
 import org.youcancook.gobong.domain.user.entity.OAuthProvider;
 import org.youcancook.gobong.domain.user.entity.User;
-import org.youcancook.gobong.domain.user.exception.AlreadyExistUserException;
+import org.youcancook.gobong.domain.user.exception.UserAlreadyExistsException;
 import org.youcancook.gobong.domain.user.exception.DuplicationNicknameException;
 import org.youcancook.gobong.domain.user.repository.UserRepository;
 import org.youcancook.gobong.global.util.token.TokenDto;
@@ -47,7 +47,7 @@ public class UserSignupService {
 
     private void validateExistUser(OAuthProvider oAuthProvider, String oAuthId) {
         if (userRepository.existsByOAuthProviderAndOAuthId(oAuthProvider, oAuthId)) {
-            throw new AlreadyExistUserException();
+            throw new UserAlreadyExistsException();
         }
     }
 

--- a/backend/src/main/java/org/youcancook/gobong/global/error/ErrorCode.java
+++ b/backend/src/main/java/org/youcancook/gobong/global/error/ErrorCode.java
@@ -31,7 +31,7 @@ public enum ErrorCode {
     // User
     DUPLICATE_NICKNAME(HttpStatus.BAD_REQUEST, "U001", "이미 등록된 닉네임입니다."),
     USER_NOT_FOUND(HttpStatus.NOT_FOUND, "U004", "유저를 찾을 수 없습니다."),
-    ALREADY_EXIST_USER(HttpStatus.BAD_REQUEST, "U001", "이미 등록된 유저입니다."),
+    USER_ALREADY_EXISTS(HttpStatus.BAD_REQUEST, "U001", "이미 등록된 유저입니다."),
 
     // Recipe
     RECIPE_NOT_FOUND(HttpStatus.NOT_FOUND, "R004", "레시피를 찾을 수 없습니다."),

--- a/backend/src/main/java/org/youcancook/gobong/global/error/ErrorCode.java
+++ b/backend/src/main/java/org/youcancook/gobong/global/error/ErrorCode.java
@@ -31,6 +31,7 @@ public enum ErrorCode {
     // User
     DUPLICATE_NICKNAME(HttpStatus.BAD_REQUEST, "U001", "이미 등록된 닉네임입니다."),
     USER_NOT_FOUND(HttpStatus.NOT_FOUND, "U004", "유저를 찾을 수 없습니다."),
+    ALREADY_EXIST_USER(HttpStatus.BAD_REQUEST, "U001", "이미 등록된 유저입니다."),
 
     // Recipe
     RECIPE_NOT_FOUND(HttpStatus.NOT_FOUND, "R004", "레시피를 찾을 수 없습니다."),

--- a/backend/src/test/java/org/youcancook/gobong/domain/user/controller/UserControllerTest.java
+++ b/backend/src/test/java/org/youcancook/gobong/domain/user/controller/UserControllerTest.java
@@ -244,6 +244,27 @@ class UserControllerTest {
         assertThat(temporaryTokens).hasSize(1);
     }
 
+    @Test
+    @DisplayName("회원가입 실패 - 이미 존재하는 유저")
+    void signupFailByExitUser() throws Exception {
+        // given
+        String temporaryToken = temporaryTokenService.saveTemporaryToken();
+        User savedUser = saveTestUser();
+
+        // when
+        SignupRequest signupRequest = new SignupRequest("notExits", savedUser.getOAuthProvider().name(), savedUser.getOAuthId(), temporaryToken, "profileImageURL");
+        String request = objectMapper.writeValueAsString(signupRequest);
+        mockMvc.perform(post("/api/users/signup")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(request))
+                .andExpect(jsonPath("$.code").value(ErrorCode.ALREADY_EXIST_USER.getCode()))
+                .andExpect(jsonPath("$.message").value(ErrorCode.ALREADY_EXIST_USER.getMessage()))
+                .andDo(print());
+
+        List<TemporaryToken> temporaryTokens = temporaryTokenRepository.findAll();
+        assertThat(temporaryTokens).hasSize(1);
+    }
+
     private User saveTestUser() {
         User user = User.builder()
                 .oAuthId("12345678")

--- a/backend/src/test/java/org/youcancook/gobong/domain/user/controller/UserControllerTest.java
+++ b/backend/src/test/java/org/youcancook/gobong/domain/user/controller/UserControllerTest.java
@@ -257,8 +257,8 @@ class UserControllerTest {
         mockMvc.perform(post("/api/users/signup")
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(request))
-                .andExpect(jsonPath("$.code").value(ErrorCode.ALREADY_EXIST_USER.getCode()))
-                .andExpect(jsonPath("$.message").value(ErrorCode.ALREADY_EXIST_USER.getMessage()))
+                .andExpect(jsonPath("$.code").value(ErrorCode.USER_ALREADY_EXISTS.getCode()))
+                .andExpect(jsonPath("$.message").value(ErrorCode.USER_ALREADY_EXISTS.getMessage()))
                 .andDo(print());
 
         List<TemporaryToken> temporaryTokens = temporaryTokenRepository.findAll();

--- a/backend/src/test/java/org/youcancook/gobong/domain/user/service/UserSignupServiceTest.java
+++ b/backend/src/test/java/org/youcancook/gobong/domain/user/service/UserSignupServiceTest.java
@@ -12,7 +12,7 @@ import org.youcancook.gobong.domain.user.dto.SignupDto;
 import org.youcancook.gobong.domain.user.dto.response.SignupResponse;
 import org.youcancook.gobong.domain.user.entity.OAuthProvider;
 import org.youcancook.gobong.domain.user.entity.User;
-import org.youcancook.gobong.domain.user.exception.AlreadyExistUserException;
+import org.youcancook.gobong.domain.user.exception.UserAlreadyExistsException;
 import org.youcancook.gobong.domain.user.exception.DuplicationNicknameException;
 import org.youcancook.gobong.domain.user.repository.UserRepository;
 import org.youcancook.gobong.global.util.token.TokenDto;
@@ -109,7 +109,7 @@ class UserSignupServiceTest {
                 .oAuthId("123456789")
                 .profileImageURL("profileImageURL")
                 .build();
-        assertThrows(AlreadyExistUserException.class,
+        assertThrows(UserAlreadyExistsException.class,
                 () -> userSignupService.signup(signupDto));
     }
 

--- a/backend/src/test/java/org/youcancook/gobong/domain/user/service/UserSignupServiceTest.java
+++ b/backend/src/test/java/org/youcancook/gobong/domain/user/service/UserSignupServiceTest.java
@@ -59,7 +59,7 @@ class UserSignupServiceTest {
 
         // when
         SignupDto signupDto = SignupDto.builder()
-                .oAuthProvider(OAuthProvider.KAKAO.name())
+                .oAuthProvider(OAuthProvider.KAKAO)
                 .nickname("nickname")
                 .oAuthId("123456789")
                 .profileImageURL("profileImageURL")
@@ -81,7 +81,7 @@ class UserSignupServiceTest {
 
         // when
         SignupDto signupDto = SignupDto.builder()
-                .oAuthProvider(OAuthProvider.KAKAO.name())
+                .oAuthProvider(OAuthProvider.KAKAO)
                 .nickname("nickname")
                 .oAuthId("123456789")
                 .profileImageURL("profileImageURL")


### PR DESCRIPTION
## 개요 🧾
https://github.com/you-can-cook/Gobong/issues/25#issue-1845185665

## 변경사항 🛠
`existsByOAuthProviderAndOAuthId` 메소드에서 (저번과 같은) 메소드 쿼리 버그 문제로 JPQL을 사용했습니다.
또한 JPQL에서는 limit를 사용 못해서 네이티브 쿼리로 고려했었으나, 테스트 오류가 발생해 현재 코드처럼 작성했습니다.
더 좋은 쿼리 방법있으면 알려주세요.
ref: https://jojoldu.tistory.com/516

