### PR TITLE
feat: 팔로우, 팔로잉 API 생성

### DIFF
--- a/backend/src/main/java/org/youcancook/gobong/domain/follow/controller/FollowController.java
+++ b/backend/src/main/java/org/youcancook/gobong/domain/follow/controller/FollowController.java
@@ -2,12 +2,13 @@ package org.youcancook.gobong.domain.follow.controller;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
+import org.youcancook.gobong.domain.follow.dto.response.FindFolloweeResponse;
+import org.youcancook.gobong.domain.follow.dto.response.FindFollowerResponse;
 import org.youcancook.gobong.domain.follow.service.FollowService;
 import org.youcancook.gobong.global.resolver.LoginUserId;
+
+import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
@@ -28,5 +29,17 @@ public class FollowController {
                                          @PathVariable Long folloeeId) {
         followService.unfollow(loginUserId, folloeeId);
         return ResponseEntity.ok().build();
+    }
+
+    @GetMapping("follower")
+    public ResponseEntity<List<FindFollowerResponse>> findFollowerList(@LoginUserId Long loginUserId) {
+        List<FindFollowerResponse> response = followService.findFollowerList(loginUserId);
+        return ResponseEntity.ok(response);
+    }
+
+    @GetMapping("following")
+    public ResponseEntity<List<FindFolloweeResponse>> findFollowingList(@LoginUserId Long loginUserId) {
+        List<FindFolloweeResponse> response = followService.findFolloeeList(loginUserId);
+        return ResponseEntity.ok(response);
     }
 }

--- a/backend/src/main/java/org/youcancook/gobong/domain/follow/dto/response/FindFolloweeResponse.java
+++ b/backend/src/main/java/org/youcancook/gobong/domain/follow/dto/response/FindFolloweeResponse.java
@@ -1,0 +1,22 @@
+package org.youcancook.gobong.domain.follow.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@AllArgsConstructor
+public class FindFolloweeResponse {
+    private String profileImageURL;
+    private String nickname;
+    private long userId;
+
+    public static FindFolloweeResponse of(String profileImageURL, String nickname, long userId) {
+        return FindFolloweeResponse.builder()
+                .profileImageURL(profileImageURL)
+                .nickname(nickname)
+                .userId(userId)
+                .build();
+    }
+}

--- a/backend/src/main/java/org/youcancook/gobong/domain/follow/dto/response/FindFolloweeResponse.java
+++ b/backend/src/main/java/org/youcancook/gobong/domain/follow/dto/response/FindFolloweeResponse.java
@@ -8,15 +8,15 @@ import lombok.Getter;
 @Builder
 @AllArgsConstructor
 public class FindFolloweeResponse {
-    private String profileImageURL;
-    private String nickname;
     private long userId;
+    private String nickname;
+    private String profileImageURL;
 
-    public static FindFolloweeResponse of(String profileImageURL, String nickname, long userId) {
+    public static FindFolloweeResponse of(long userId, String nickname, String profileImageURL) {
         return FindFolloweeResponse.builder()
-                .profileImageURL(profileImageURL)
-                .nickname(nickname)
                 .userId(userId)
+                .nickname(nickname)
+                .profileImageURL(profileImageURL)
                 .build();
     }
 }

--- a/backend/src/main/java/org/youcancook/gobong/domain/follow/dto/response/FindFollowerResponse.java
+++ b/backend/src/main/java/org/youcancook/gobong/domain/follow/dto/response/FindFollowerResponse.java
@@ -1,0 +1,22 @@
+package org.youcancook.gobong.domain.follow.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@AllArgsConstructor
+public class FindFollowerResponse {
+    private String profileImageURL;
+    private String nickname;
+    private long userId;
+
+    public static FindFollowerResponse of(String profileImageURL, String nickname, long userId) {
+        return FindFollowerResponse.builder()
+                .profileImageURL(profileImageURL)
+                .nickname(nickname)
+                .userId(userId)
+                .build();
+    }
+}

--- a/backend/src/main/java/org/youcancook/gobong/domain/follow/dto/response/FindFollowerResponse.java
+++ b/backend/src/main/java/org/youcancook/gobong/domain/follow/dto/response/FindFollowerResponse.java
@@ -8,15 +8,15 @@ import lombok.Getter;
 @Builder
 @AllArgsConstructor
 public class FindFollowerResponse {
-    private String profileImageURL;
-    private String nickname;
     private long userId;
+    private String nickname;
+    private String profileImageURL;
 
-    public static FindFollowerResponse of(String profileImageURL, String nickname, long userId) {
+    public static FindFollowerResponse of(long userId, String nickname, String profileImageURL) {
         return FindFollowerResponse.builder()
-                .profileImageURL(profileImageURL)
-                .nickname(nickname)
                 .userId(userId)
+                .nickname(nickname)
+                .profileImageURL(profileImageURL)
                 .build();
     }
 }

--- a/backend/src/main/java/org/youcancook/gobong/domain/follow/repository/FollowRepository.java
+++ b/backend/src/main/java/org/youcancook/gobong/domain/follow/repository/FollowRepository.java
@@ -1,13 +1,21 @@
 package org.youcancook.gobong.domain.follow.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.youcancook.gobong.domain.follow.entity.Follow;
 import org.youcancook.gobong.domain.user.entity.User;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface FollowRepository extends JpaRepository<Follow, Long> {
     boolean existsByFollowerAndFollowee(User follower, User followee);
 
     Optional<Follow> findByFollowerAndFollowee(User follower, User followee);
+
+    @Query("select f from Follow f join fetch f.follower")
+    List<Follow> findByFollowee(User followee);
+
+    @Query("select f from Follow f join fetch f.followee")
+    List<Follow> findByFollower(User follower);
 }

--- a/backend/src/main/java/org/youcancook/gobong/domain/follow/service/FollowService.java
+++ b/backend/src/main/java/org/youcancook/gobong/domain/follow/service/FollowService.java
@@ -63,9 +63,9 @@ public class FollowService {
 
         return followRepository.findByFollowee(user).stream()
                 .map(follow -> FindFollowerResponse.of(
-                        follow.getFollower().getProfileImageURL(),
+                        follow.getFollower().getId(),
                         follow.getFollower().getNickname(),
-                        follow.getFollower().getId()
+                        follow.getFollower().getProfileImageURL()
                 ))
                 .toList();
     }
@@ -76,9 +76,9 @@ public class FollowService {
 
         return followRepository.findByFollower(user).stream()
                 .map(follow -> FindFolloweeResponse.of(
-                        follow.getFollowee().getProfileImageURL(),
+                        follow.getFollowee().getId(),
                         follow.getFollowee().getNickname(),
-                        follow.getFollowee().getId()
+                        follow.getFollowee().getProfileImageURL()
                 ))
                 .toList();
     }

--- a/backend/src/main/java/org/youcancook/gobong/domain/follow/service/FollowService.java
+++ b/backend/src/main/java/org/youcancook/gobong/domain/follow/service/FollowService.java
@@ -3,6 +3,8 @@ package org.youcancook.gobong.domain.follow.service;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.youcancook.gobong.domain.follow.dto.response.FindFolloweeResponse;
+import org.youcancook.gobong.domain.follow.dto.response.FindFollowerResponse;
 import org.youcancook.gobong.domain.follow.entity.Follow;
 import org.youcancook.gobong.domain.follow.exception.AlreadyFollowingException;
 import org.youcancook.gobong.domain.follow.exception.NotFollowingException;
@@ -11,8 +13,11 @@ import org.youcancook.gobong.domain.user.entity.User;
 import org.youcancook.gobong.domain.user.exception.UserNotFoundException;
 import org.youcancook.gobong.domain.user.repository.UserRepository;
 
+import java.util.List;
+
 @Service
 @RequiredArgsConstructor
+@Transactional(readOnly = true)
 public class FollowService {
 
     private final UserRepository userRepository;
@@ -50,5 +55,31 @@ public class FollowService {
         Follow follow = followRepository.findByFollowerAndFollowee(follower, followee)
                 .orElseThrow(NotFollowingException::new);
         followRepository.delete(follow);
+    }
+
+    public List<FindFollowerResponse> findFollowerList(Long loginUserId) {
+        User user = userRepository.findById(loginUserId)
+                .orElseThrow(UserNotFoundException::new);
+
+        return followRepository.findByFollowee(user).stream()
+                .map(follow -> FindFollowerResponse.of(
+                        follow.getFollower().getProfileImageURL(),
+                        follow.getFollower().getNickname(),
+                        follow.getFollower().getId()
+                ))
+                .toList();
+    }
+
+    public List<FindFolloweeResponse> findFolloeeList(Long loginUserId) {
+        User user = userRepository.findById(loginUserId)
+                .orElseThrow(UserNotFoundException::new);
+
+        return followRepository.findByFollower(user).stream()
+                .map(follow -> FindFolloweeResponse.of(
+                        follow.getFollowee().getProfileImageURL(),
+                        follow.getFollowee().getNickname(),
+                        follow.getFollowee().getId()
+                ))
+                .toList();
     }
 }


### PR DESCRIPTION
## 개요 🧾
팔로우, 팔로잉 API 생성

## 변경사항 🛠
- 나를 팔로우하는 유저 조회 API
  - URL : GET `api/follower`
  - Response 예시
  ```json
  [
    {
      "profileImageURL": "profileImageURL9",
      "nickname": "nickname9",
      "userId": 9
    },
    {
      "profileImageURL": "profileImageURL10",
      "nickname": "nickname10",
      "userId": 10
    }
  ]
  ```
- 내가 팔로우하는 유저 조회 API
  - URL : GET `api/following`
  - Response 예시
  ```json
  [
    {
      "profileImageURL": "profileImageURL9",
      "nickname": "nickname9",
      "userId": 9
    },
    {
      "profileImageURL": "profileImageURL10",
      "nickname": "nickname10",
      "userId": 10
    }
  ]
  ```

## 주의사항 ⚠
- Lazy loading에 따른 N+1 문제를 해결하기 위해 Fetch join을 사용했습니다.

```java
@Query("select f from Follow f join fetch f.follower")
List<Follow> findByFollowee(User followee);

@Query("select f from Follow f join fetch f.followee")
List<Follow> findByFollower(User follower);
```
