### PR TITLE
fix: Basetime 타임스탬프가 데이터베이스에 기록되지 않던 버그 수정

### DIFF
--- a/backend/src/main/java/org/youcancook/gobong/GobongApplication.java
+++ b/backend/src/main/java/org/youcancook/gobong/GobongApplication.java
@@ -2,7 +2,9 @@ package org.youcancook.gobong;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
+@EnableJpaAuditing
 @SpringBootApplication
 public class GobongApplication {
 

--- a/backend/src/test/java/org/youcancook/gobong/domain/BaseTime/BaseTimeTest.java
+++ b/backend/src/test/java/org/youcancook/gobong/domain/BaseTime/BaseTimeTest.java
@@ -1,0 +1,60 @@
+package org.youcancook.gobong.domain.BaseTime;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
+import org.youcancook.gobong.domain.recipe.entity.Difficulty;
+import org.youcancook.gobong.domain.recipe.entity.Recipe;
+import org.youcancook.gobong.domain.recipe.repository.RecipeRepository;
+import org.youcancook.gobong.domain.user.entity.OAuthProvider;
+import org.youcancook.gobong.domain.user.entity.User;
+import org.youcancook.gobong.domain.user.repository.UserRepository;
+
+import java.time.LocalDateTime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DataJpaTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+class BaseTimeTest {
+
+    @Autowired
+    UserRepository userRepository;
+    @Autowired
+    RecipeRepository recipeRepository;
+    @Autowired
+    TestEntityManager entityManager;
+
+    @Test
+    @DisplayName("레시피를 데이터베이스에 저장 시, 타임스탬프가 저장된다.")
+    public void createRecipe(){
+        User user1 = new User("name1", "oauth1", OAuthProvider.GOOGLE, null);
+        Recipe recipe1 = Recipe.builder().user(user1).difficulty(Difficulty.EASY).title("주먹밥1").build();
+        userRepository.save(user1);
+        recipeRepository.save(recipe1);
+
+        assertThat(recipe1.getCreatedAt()).isNotNull();
+    }
+    
+    @Test
+    @DisplayName("레시피를 수정 시, 수정 타임스탬프가 저장된다.")
+    public void modifyRecipe(){
+        User user1 = new User("name1", "oauth1", OAuthProvider.GOOGLE, null);
+        User user2 = new User("name2", "oauth2", OAuthProvider.KAKAO, null);
+        Recipe recipe1 = Recipe.builder().user(user1).difficulty(Difficulty.EASY).title("주먹밥1").build();
+        userRepository.save(user1);
+        userRepository.save(user2);
+        recipeRepository.save(recipe1);
+        recipe1.updateProperties("주먹밥", "", "김,밥", Difficulty.EASY, null);
+        entityManager.flush();
+
+        LocalDateTime createdAt = recipe1.getCreatedAt();
+        LocalDateTime modifiedAt = recipe1.getModifiedAt();
+        assertThat(modifiedAt).isNotNull();
+        assertThat(createdAt).isNotNull();
+        assertThat(modifiedAt).isAfter(createdAt);
+    }
+}


### PR DESCRIPTION
## 개요 🧾
<!-- 이곳에 PR의 내용을 간단하게 작성해주세요. -->
`@EnableJpaAuditing`이 추가되지 않아 DB에 타임스탬프가 `null`로 기록되던 버그를 고쳤습니다.
테스트를 잘 짜야겠네요 😢 

## 주의사항 ⚠
<!-- 이곳에 리뷰어에게 할 말이나, 주의해야 하는 점에 대해서 작성해 주세요 -->
`user`가 H2 DB 예약어라 `@DataJpaTest`에서 추가 작업을 진행했습니다. 코멘트 남길게요!