### PR TITLE
feat: 북마크한 레시피 조회 기능 구현

### DIFF
--- a/backend/src/main/java/org/youcancook/gobong/GobongApplication.java
+++ b/backend/src/main/java/org/youcancook/gobong/GobongApplication.java
@@ -2,7 +2,9 @@ package org.youcancook.gobong;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
+@EnableJpaAuditing
 @SpringBootApplication
 public class GobongApplication {
 

--- a/backend/src/main/java/org/youcancook/gobong/domain/bookmarkrecipe/dto/TotalBookmarkDto.java
+++ b/backend/src/main/java/org/youcancook/gobong/domain/bookmarkrecipe/dto/TotalBookmarkDto.java
@@ -1,0 +1,14 @@
+package org.youcancook.gobong.domain.bookmarkrecipe.dto;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class TotalBookmarkDto {
+    private Long recipeId;
+    private Long totalBookmarkCount;
+}

--- a/backend/src/main/java/org/youcancook/gobong/domain/bookmarkrecipe/entity/BookmarkRecipe.java
+++ b/backend/src/main/java/org/youcancook/gobong/domain/bookmarkrecipe/entity/BookmarkRecipe.java
@@ -35,7 +35,6 @@ public class BookmarkRecipe extends BaseTime {
     public BookmarkRecipe(User user, Recipe recipe) {
         this.user = user;
         this.recipe = recipe;
-        recipe.addBookmark(this);
     }
 }
 

--- a/backend/src/main/java/org/youcancook/gobong/domain/bookmarkrecipe/entity/BookmarkRecipe.java
+++ b/backend/src/main/java/org/youcancook/gobong/domain/bookmarkrecipe/entity/BookmarkRecipe.java
@@ -5,6 +5,7 @@ import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.youcancook.gobong.domain.BaseTime.BaseTime;
 import org.youcancook.gobong.domain.recipe.entity.Recipe;
 import org.youcancook.gobong.domain.user.entity.User;
 
@@ -15,7 +16,7 @@ import org.youcancook.gobong.domain.user.entity.User;
         uniqueConstraints = {
         @UniqueConstraint(columnNames = {"user_id", "recipe_id"})
 })
-public class BookmarkRecipe {
+public class BookmarkRecipe extends BaseTime {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -34,6 +35,7 @@ public class BookmarkRecipe {
     public BookmarkRecipe(User user, Recipe recipe) {
         this.user = user;
         this.recipe = recipe;
+        recipe.addBookmark(this);
     }
 }
 

--- a/backend/src/main/java/org/youcancook/gobong/domain/bookmarkrecipe/repository/BookmarkRecipeRepository.java
+++ b/backend/src/main/java/org/youcancook/gobong/domain/bookmarkrecipe/repository/BookmarkRecipeRepository.java
@@ -3,8 +3,10 @@ package org.youcancook.gobong.domain.bookmarkrecipe.repository;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
+import org.youcancook.gobong.domain.bookmarkrecipe.dto.TotalBookmarkDto;
 import org.youcancook.gobong.domain.bookmarkrecipe.entity.BookmarkRecipe;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface BookmarkRecipeRepository extends JpaRepository<BookmarkRecipe, Long> {
@@ -15,5 +17,12 @@ public interface BookmarkRecipeRepository extends JpaRepository<BookmarkRecipe, 
     @Modifying
     @Query("DELETE FROM BookmarkRecipe bm where bm.recipe.id =:recipeId")
     void deleteAllByRecipeId(Long recipeId);
+
+    @Query("SELECT NEW org.youcancook.gobong.domain.bookmarkrecipe.dto.TotalBookmarkDto(r.id, COUNT(*)) " +
+            "FROM BookmarkRecipe bm " +
+            "JOIN bm.recipe r " +
+            "WHERE r.id IN :recipeIds " +
+            "GROUP BY r.id")
+    List<TotalBookmarkDto> getTotalBookmarks(List<Long> recipeIds);
 
 }

--- a/backend/src/main/java/org/youcancook/gobong/domain/rating/dto/RatingDto.java
+++ b/backend/src/main/java/org/youcancook/gobong/domain/rating/dto/RatingDto.java
@@ -1,0 +1,14 @@
+package org.youcancook.gobong.domain.rating.dto;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class RatingDto {
+    private Long recipeId;
+    private Double averageScore;
+}

--- a/backend/src/main/java/org/youcancook/gobong/domain/rating/entity/Rating.java
+++ b/backend/src/main/java/org/youcancook/gobong/domain/rating/entity/Rating.java
@@ -43,7 +43,6 @@ public class Rating {
         this.user = user;
         this.recipe = recipe;
         this.score = score;
-        this.recipe.addRating(this);
     }
     public void updateScore(Integer score) {
         validateRatingRange(score);

--- a/backend/src/main/java/org/youcancook/gobong/domain/rating/repository/RatingRepository.java
+++ b/backend/src/main/java/org/youcancook/gobong/domain/rating/repository/RatingRepository.java
@@ -3,12 +3,23 @@ package org.youcancook.gobong.domain.rating.repository;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
+import org.youcancook.gobong.domain.rating.dto.RatingDto;
 import org.youcancook.gobong.domain.rating.entity.Rating;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface RatingRepository extends JpaRepository<Rating, Long> {
+
+    @Query("SELECT r FROM Rating r join r.user u join r.recipe recipe WHERE u.id =:userId AND recipe.id =:recipeId")
     Optional<Rating> findByUserIdAndRecipeId(Long userId, Long recipeId);
+
+    @Query("SELECT NEW org.youcancook.gobong.domain.rating.dto.RatingDto(recipe.id, AVG(r.score)) " +
+            "FROM Rating r " +
+            "join r.recipe recipe " +
+            "WHERE recipe.id IN :recipeIds " +
+            "GROUP BY recipe.id")
+    List<RatingDto> getAverageRatings(List<Long> recipeIds);
 
     @Modifying
     @Query("DELETE FROM Rating r where r.recipe.id =:recipeId")

--- a/backend/src/main/java/org/youcancook/gobong/domain/recipe/controller/RecipeController.java
+++ b/backend/src/main/java/org/youcancook/gobong/domain/recipe/controller/RecipeController.java
@@ -6,6 +6,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import org.youcancook.gobong.domain.recipe.dto.request.CreateRecipeRequest;
 import org.youcancook.gobong.domain.recipe.dto.request.UpdateRecipeRequest;
+import org.youcancook.gobong.domain.recipe.dto.response.BookmarkedRecipesResponse;
 import org.youcancook.gobong.domain.recipe.dto.response.CreateRecipeResponse;
 import org.youcancook.gobong.domain.recipe.service.RecipeService;
 import org.youcancook.gobong.global.resolver.LoginUserId;
@@ -36,5 +37,13 @@ public class RecipeController {
 
         recipeService.deleteRecipe(userId, recipeId);
         return ResponseEntity.ok().build();
+    }
+
+    @GetMapping("/bookmarks")
+    public ResponseEntity<BookmarkedRecipesResponse> getBookmarkedRecipes(@LoginUserId Long userId,
+                                                                          @RequestParam("page") final Integer page,
+                                                                          @RequestParam("count") final int count){
+        BookmarkedRecipesResponse allBookmarkedRecipes = recipeService.getAllBookmarkedRecipes(userId, page, count);
+        return ResponseEntity.ok(allBookmarkedRecipes);
     }
 }

--- a/backend/src/main/java/org/youcancook/gobong/domain/recipe/dto/response/BookmarkedRecipeResponse.java
+++ b/backend/src/main/java/org/youcancook/gobong/domain/recipe/dto/response/BookmarkedRecipeResponse.java
@@ -1,0 +1,22 @@
+package org.youcancook.gobong.domain.recipe.dto.response;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class BookmarkedRecipeResponse {
+
+    private Long recipeId;
+    private Long userId;
+    private Integer totalTimeInSeconds;
+    private String thumbnailURL;
+    private String difficulty;
+    private Double averageRating;
+    private long cookwares;
+    private int totalBookmarks;
+
+}

--- a/backend/src/main/java/org/youcancook/gobong/domain/recipe/dto/response/BookmarkedRecipesResponse.java
+++ b/backend/src/main/java/org/youcancook/gobong/domain/recipe/dto/response/BookmarkedRecipesResponse.java
@@ -1,0 +1,16 @@
+package org.youcancook.gobong.domain.recipe.dto.response;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class BookmarkedRecipesResponse {
+    private boolean isLast;
+    private List<BookmarkedRecipeResponse> recipes;
+}

--- a/backend/src/main/java/org/youcancook/gobong/domain/recipe/entity/Recipe.java
+++ b/backend/src/main/java/org/youcancook/gobong/domain/recipe/entity/Recipe.java
@@ -6,12 +6,7 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.youcancook.gobong.domain.BaseTime.BaseTime;
-import org.youcancook.gobong.domain.bookmarkrecipe.entity.BookmarkRecipe;
-import org.youcancook.gobong.domain.rating.entity.Rating;
 import org.youcancook.gobong.domain.user.entity.User;
-
-import java.util.ArrayList;
-import java.util.List;
 
 @Entity
 @Getter
@@ -47,12 +42,6 @@ public class Recipe extends BaseTime {
     @Column(nullable = false)
     private Integer totalCookTimeInSeconds;
 
-    @OneToMany(mappedBy = "recipe")
-    private List<Rating> rating = new ArrayList<>();
-
-    @OneToMany(mappedBy = "recipe")
-    private List<BookmarkRecipe> bookmarks = new ArrayList<>();
-
     @Builder
     public Recipe(User user, String title, String introduction, String ingredients, Difficulty difficulty,
                   String thumbnailURL) {
@@ -64,21 +53,6 @@ public class Recipe extends BaseTime {
         this.thumbnailURL = thumbnailURL;
         cookwares = 0L;
         totalCookTimeInSeconds = 0;
-    }
-
-    public void addBookmark(BookmarkRecipe bookmarkRecipe) {
-        this.bookmarks.add(bookmarkRecipe);
-    }
-
-    public void addRating(Rating rating){
-        this.rating.add(rating);
-    }
-
-    public double getAverageRating(){
-        return rating.stream()
-                .mapToDouble(Rating::getScore)
-                .average()
-                .orElse(0.0);
     }
 
     public void updateProperties(String title, String introduction, String ingredients,

--- a/backend/src/main/java/org/youcancook/gobong/domain/recipe/entity/Recipe.java
+++ b/backend/src/main/java/org/youcancook/gobong/domain/recipe/entity/Recipe.java
@@ -6,6 +6,7 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.youcancook.gobong.domain.BaseTime.BaseTime;
+import org.youcancook.gobong.domain.bookmarkrecipe.entity.BookmarkRecipe;
 import org.youcancook.gobong.domain.rating.entity.Rating;
 import org.youcancook.gobong.domain.user.entity.User;
 
@@ -49,6 +50,9 @@ public class Recipe extends BaseTime {
     @OneToMany(mappedBy = "recipe")
     private List<Rating> rating = new ArrayList<>();
 
+    @OneToMany(mappedBy = "recipe")
+    private List<BookmarkRecipe> bookmarks = new ArrayList<>();
+
     @Builder
     public Recipe(User user, String title, String introduction, String ingredients, Difficulty difficulty,
                   String thumbnailURL) {
@@ -60,6 +64,10 @@ public class Recipe extends BaseTime {
         this.thumbnailURL = thumbnailURL;
         cookwares = 0L;
         totalCookTimeInSeconds = 0;
+    }
+
+    public void addBookmark(BookmarkRecipe bookmarkRecipe) {
+        this.bookmarks.add(bookmarkRecipe);
     }
 
     public void addRating(Rating rating){

--- a/backend/src/main/java/org/youcancook/gobong/domain/recipe/repository/RecipeRepository.java
+++ b/backend/src/main/java/org/youcancook/gobong/domain/recipe/repository/RecipeRepository.java
@@ -1,7 +1,13 @@
 package org.youcancook.gobong.domain.recipe.repository;
 
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.youcancook.gobong.domain.recipe.entity.Recipe;
 
 public interface RecipeRepository extends JpaRepository<Recipe, Long> {
+
+    @Query("SELECT r FROM BookmarkRecipe b join b.recipe r join b.user u where u.id =:userId")
+    Slice<Recipe> findByBookmarkedRecipes(Long userId, PageRequest of);
 }

--- a/backend/src/test/java/org/youcancook/gobong/domain/BaseTime/BaseTimeTest.java
+++ b/backend/src/test/java/org/youcancook/gobong/domain/BaseTime/BaseTimeTest.java
@@ -1,0 +1,60 @@
+package org.youcancook.gobong.domain.BaseTime;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
+import org.youcancook.gobong.domain.recipe.entity.Difficulty;
+import org.youcancook.gobong.domain.recipe.entity.Recipe;
+import org.youcancook.gobong.domain.recipe.repository.RecipeRepository;
+import org.youcancook.gobong.domain.user.entity.OAuthProvider;
+import org.youcancook.gobong.domain.user.entity.User;
+import org.youcancook.gobong.domain.user.repository.UserRepository;
+
+import java.time.LocalDateTime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DataJpaTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+class BaseTimeTest {
+
+    @Autowired
+    UserRepository userRepository;
+    @Autowired
+    RecipeRepository recipeRepository;
+    @Autowired
+    TestEntityManager entityManager;
+
+    @Test
+    @DisplayName("레시피를 데이터베이스에 저장 시, 타임스탬프가 저장된다.")
+    public void createRecipe(){
+        User user1 = new User("name1", "oauth1", OAuthProvider.GOOGLE, null);
+        Recipe recipe1 = Recipe.builder().user(user1).difficulty(Difficulty.EASY).title("주먹밥1").build();
+        userRepository.save(user1);
+        recipeRepository.save(recipe1);
+
+        assertThat(recipe1.getCreatedAt()).isNotNull();
+    }
+    
+    @Test
+    @DisplayName("레시피를 수정 시, 수정 타임스탬프가 저장된다.")
+    public void modifyRecipe(){
+        User user1 = new User("name1", "oauth1", OAuthProvider.GOOGLE, null);
+        User user2 = new User("name2", "oauth2", OAuthProvider.KAKAO, null);
+        Recipe recipe1 = Recipe.builder().user(user1).difficulty(Difficulty.EASY).title("주먹밥1").build();
+        userRepository.save(user1);
+        userRepository.save(user2);
+        recipeRepository.save(recipe1);
+        recipe1.updateProperties("주먹밥", "", "김,밥", Difficulty.EASY, null);
+        entityManager.flush();
+
+        LocalDateTime createdAt = recipe1.getCreatedAt();
+        LocalDateTime modifiedAt = recipe1.getModifiedAt();
+        assertThat(modifiedAt).isNotNull();
+        assertThat(createdAt).isNotNull();
+        assertThat(modifiedAt).isAfter(createdAt);
+    }
+}

--- a/backend/src/test/java/org/youcancook/gobong/domain/bookmarkrecipe/repository/BookmarkRecipeRepositoryTest.java
+++ b/backend/src/test/java/org/youcancook/gobong/domain/bookmarkrecipe/repository/BookmarkRecipeRepositoryTest.java
@@ -1,0 +1,71 @@
+package org.youcancook.gobong.domain.bookmarkrecipe.repository;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.youcancook.gobong.domain.bookmarkrecipe.dto.TotalBookmarkDto;
+import org.youcancook.gobong.domain.bookmarkrecipe.entity.BookmarkRecipe;
+import org.youcancook.gobong.domain.recipe.entity.Difficulty;
+import org.youcancook.gobong.domain.recipe.entity.Recipe;
+import org.youcancook.gobong.domain.recipe.repository.RecipeRepository;
+import org.youcancook.gobong.domain.user.entity.OAuthProvider;
+import org.youcancook.gobong.domain.user.entity.User;
+import org.youcancook.gobong.domain.user.repository.UserRepository;
+
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DataJpaTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+class BookmarkRecipeRepositoryTest {
+
+    @Autowired
+    UserRepository userRepository;
+    @Autowired
+    RecipeRepository recipeRepository;
+    @Autowired
+    BookmarkRecipeRepository bookmarkRecipeRepository;
+
+    @Test
+    @DisplayName("레시피의 총 북마크 합을 올바르게 조회한다.")
+    public void getTotalBookmarkCount(){
+        User user1 = User.builder().nickname("abc").oAuthId("1231").oAuthProvider(OAuthProvider.GOOGLE).build();
+        User user2 = User.builder().nickname("def").oAuthId("1232").oAuthProvider(OAuthProvider.GOOGLE).build();
+        User user3 = User.builder().nickname("ghi").oAuthId("1233").oAuthProvider(OAuthProvider.GOOGLE).build();
+        User user4 = User.builder().nickname("ghdd").oAuthId("1234").oAuthProvider(OAuthProvider.GOOGLE).build();
+        userRepository.save(user1);
+        userRepository.save(user2);
+        userRepository.save(user3);
+        userRepository.save(user4);
+
+        Recipe recipe1 = Recipe.builder().title("주먹밥1").difficulty(Difficulty.EASY).user(user1).build();
+        Recipe recipe2 = Recipe.builder().title("주먹밥2").difficulty(Difficulty.EASY).user(user1).build();
+        recipeRepository.save(recipe1);
+        recipeRepository.save(recipe2);
+
+        bookmarkRecipeRepository.save(new BookmarkRecipe(user2, recipe1));
+        bookmarkRecipeRepository.save(new BookmarkRecipe(user3, recipe1));
+        bookmarkRecipeRepository.save(new BookmarkRecipe(user4, recipe1));
+
+        bookmarkRecipeRepository.save(new BookmarkRecipe(user2, recipe2));
+        bookmarkRecipeRepository.save(new BookmarkRecipe(user3, recipe2));
+
+        List<Long> recipeIds = List.of(recipe1.getId(), recipe2.getId());
+        List<TotalBookmarkDto> totalBookmarks = bookmarkRecipeRepository.getTotalBookmarks(recipeIds);
+        Map<Long, Long> actual = totalBookmarks.stream()
+                .collect(Collectors.toMap(
+                        TotalBookmarkDto::getRecipeId,
+                        TotalBookmarkDto::getTotalBookmarkCount
+                ));
+
+        assertThat(actual).hasSize(2);
+        assertThat(actual.get(recipe1.getId())).isEqualTo(3);
+        assertThat(actual.get(recipe2.getId())).isEqualTo(2);
+    }
+
+}

--- a/backend/src/test/java/org/youcancook/gobong/domain/rating/repository/RatingRepositoryTest.java
+++ b/backend/src/test/java/org/youcancook/gobong/domain/rating/repository/RatingRepositoryTest.java
@@ -1,0 +1,71 @@
+package org.youcancook.gobong.domain.rating.repository;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.youcancook.gobong.domain.rating.dto.RatingDto;
+import org.youcancook.gobong.domain.rating.entity.Rating;
+import org.youcancook.gobong.domain.recipe.entity.Difficulty;
+import org.youcancook.gobong.domain.recipe.entity.Recipe;
+import org.youcancook.gobong.domain.recipe.repository.RecipeRepository;
+import org.youcancook.gobong.domain.user.entity.OAuthProvider;
+import org.youcancook.gobong.domain.user.entity.User;
+import org.youcancook.gobong.domain.user.repository.UserRepository;
+
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DataJpaTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+class RatingRepositoryTest {
+
+    @Autowired
+    RatingRepository ratingRepository;
+    @Autowired
+    UserRepository userRepository;
+    @Autowired
+    RecipeRepository recipeRepository;
+
+    @Test
+    @DisplayName("평균 평점을 올바르게 조회한다.")
+    public void getAverageRating(){
+        User user1 = User.builder().nickname("abc").oAuthId("1231").oAuthProvider(OAuthProvider.GOOGLE).build();
+        User user2 = User.builder().nickname("def").oAuthId("1232").oAuthProvider(OAuthProvider.GOOGLE).build();
+        User user3 = User.builder().nickname("ghi").oAuthId("1233").oAuthProvider(OAuthProvider.GOOGLE).build();
+        userRepository.save(user1);
+        userRepository.save(user2);
+        userRepository.save(user3);
+
+        Recipe recipe1 = Recipe.builder().title("주먹밥1").difficulty(Difficulty.EASY).user(user1).build();
+        Recipe recipe2 = Recipe.builder().title("주먹밥2").difficulty(Difficulty.EASY).user(user1).build();
+        Recipe recipe3 = Recipe.builder().title("주먹밥3").difficulty(Difficulty.EASY).user(user1).build();
+        recipeRepository.save(recipe1);
+        recipeRepository.save(recipe2);
+        recipeRepository.save(recipe3);
+
+        ratingRepository.save(new Rating(user2, recipe1, 1));
+        ratingRepository.save(new Rating(user2, recipe2, 5));
+        ratingRepository.save(new Rating(user2, recipe3, 5));
+
+        ratingRepository.save(new Rating(user3, recipe1, 5));
+        ratingRepository.save(new Rating(user3, recipe2, 4));
+        ratingRepository.save(new Rating(user3, recipe3, 4));
+
+        List<Long> ids = List.of(recipe1.getId(), recipe2.getId());
+        Map<Long, Double> actual = ratingRepository.getAverageRatings(ids)
+                .stream()
+                .collect(Collectors.toMap(
+                    RatingDto::getRecipeId,
+                    RatingDto::getAverageScore
+                ));
+
+        assertThat(actual).hasSize(2);
+        assertThat(actual.get(recipe1.getId())).isEqualTo(3.0);
+        assertThat(actual.get(recipe2.getId())).isEqualTo(4.5);
+    }
+}

--- a/backend/src/test/java/org/youcancook/gobong/domain/recipe/service/RecipeAcceptanceTest.java
+++ b/backend/src/test/java/org/youcancook/gobong/domain/recipe/service/RecipeAcceptanceTest.java
@@ -95,4 +95,31 @@ public class RecipeAcceptanceTest extends AcceptanceTest {
                 .statusCode(HttpStatus.OK.value())
                 .extract();
     }
+
+    @Test
+    @DisplayName("북마크한 레시피를 조회한다.")
+    public void getBookmarks(){
+        String accessToken1 = AcceptanceUtils.signUpAndGetToken("쩝쩝박사", "KAKAO", "123");
+        String accessToken2 = AcceptanceUtils.signUpAndGetToken("냠냠학사", "GOOGLE", "1223");
+        CreateRecipeRequest request = new CreateRecipeRequest("주먹밥", "쉽게 만드는 주먹밥", List.of("밥", "김"), "쉬워요", null, List.of(
+                new UploadRecipeDetailRequest("소금간을 해 주세요", null, 30, 0L),
+                new UploadRecipeDetailRequest("주먹을 쥐어 밥을 뭉쳐주세요", null, 15, 0L)
+        ));
+
+        for(int i = 0; i < 5; i++){
+            Long recipeId = AcceptanceUtils.createDummyRecipe(accessToken1, request).as(CreateRecipeResponse.class).getId();
+            RestAssured.given().log().all()
+                    .auth().oauth2(accessToken2)
+                    .when().post("/api/bookmarks/" + recipeId)
+                    .then().log().all()
+                    .statusCode(HttpStatus.OK.value());
+        }
+
+        RestAssured.given().log().all()
+                .auth().oauth2(accessToken2)
+                .when().get("/api/recipes/bookmarks?page=0&count=5")
+                .then().log().all()
+                .extract();
+
+    }
 }


### PR DESCRIPTION
## 개요 🧾
<!-- 이곳에 PR의 내용을 간단하게 작성해주세요. -->
무한 스크롤을 사용할 예정이기 때문에 `Slice`를 사용했습니다.
`page`가 0-based index라서 프론트측과 소통이 필요합니다.

URL
`/api/recipes/bookmarks?page=0&count=5`
5개씩 잘라서, 0번째 페이지에 해당하는 것을 보여줍니다. 이 때, response의 `isLast`가 false인 경우, 뒤쪽 페이지가 더 있다는 의미로 추가 요청을 하면 됩니다 (프론트측)


## 변경사항 🛠
<!-- 이곳에 코드 변경 사항이나 추가된 사항에 대해서 작성해주세요. -->

- 북마크를 한 시간 기준으로 보여주는 게 좋다고 판단해서, `BaseTime`을 상속하도록 했습니다.
- 북마크 총 개수를 매번 쿼리보내는 게 비효율적이라고 판단해 관계를 추가했습니다.

## 주의사항 ⚠
<!-- 이곳에 리뷰어에게 할 말이나, 주의해야 하는 점에 대해서 작성해 주세요 -->
쿼리가 생각보다 많이 나가는 것 같습니다. 5개의 레시피가 포함된 하나의 페이지를 부르는 데 10개의 Select 쿼리가 나가고 있는데(각각의 레시피에 대해서 평균 평점과 총 북마크 수), N+1 문제가 발생하고 있는 것 같네요. 그것까지 해결하고 나서 머지하겠습니다

