### PR TITLE
feat: 레시피 단건 조회 구현

### DIFF
--- a/backend/src/main/java/org/youcancook/gobong/domain/bookmarkrecipe/entity/BookmarkRecipe.java
+++ b/backend/src/main/java/org/youcancook/gobong/domain/bookmarkrecipe/entity/BookmarkRecipe.java
@@ -34,6 +34,7 @@ public class BookmarkRecipe {
     public BookmarkRecipe(User user, Recipe recipe) {
         this.user = user;
         this.recipe = recipe;
+        recipe.increaseBookmarkCount();
     }
 }
 

--- a/backend/src/main/java/org/youcancook/gobong/domain/bookmarkrecipe/service/BookmarkRecipeService.java
+++ b/backend/src/main/java/org/youcancook/gobong/domain/bookmarkrecipe/service/BookmarkRecipeService.java
@@ -39,8 +39,10 @@ public class BookmarkRecipeService {
 
     @Transactional
     public void removeBookmark(Long userId, Long recipeId){
+        Recipe recipe = recipeRepository.findById(recipeId).orElseThrow(RecipeNotFoundException::new);
         BookmarkRecipe bookmarkRecipe = bookmarkRecipeRepository.findByUserIdAndRecipeId(userId, recipeId)
                 .orElseThrow(BookmarkRecipeNotFoundException::new);
+        recipe.decreaseBookmarkCount();
         bookmarkRecipeRepository.delete(bookmarkRecipe);
     }
 }

--- a/backend/src/main/java/org/youcancook/gobong/domain/follow/service/FollowService.java
+++ b/backend/src/main/java/org/youcancook/gobong/domain/follow/service/FollowService.java
@@ -13,6 +13,7 @@ import org.youcancook.gobong.domain.user.repository.UserRepository;
 
 @Service
 @RequiredArgsConstructor
+@Transactional(readOnly = true)
 public class FollowService {
 
     private final UserRepository userRepository;
@@ -51,4 +52,14 @@ public class FollowService {
                 .orElseThrow(NotFollowingException::new);
         followRepository.delete(follow);
     }
+
+    public boolean isFollowing(Long followerId, Long followeeId){
+        User follower = userRepository.findById(followerId)
+                .orElseThrow(UserNotFoundException::new);
+        User followee = userRepository.findById(followeeId)
+                .orElseThrow(UserNotFoundException::new);
+
+        return followRepository.existsByFollowerAndFollowee(follower, followee);
+    }
+
 }

--- a/backend/src/main/java/org/youcancook/gobong/domain/rating/entity/Rating.java
+++ b/backend/src/main/java/org/youcancook/gobong/domain/rating/entity/Rating.java
@@ -43,11 +43,14 @@ public class Rating {
         this.user = user;
         this.recipe = recipe;
         this.score = score;
-        this.recipe.addRating(this);
+        recipe.updateRatingDelta(score);
+        recipe.increaseTotalRatedNum();
     }
     public void updateScore(Integer score) {
         validateRatingRange(score);
+        recipe.updateRatingDelta(-this.score);
         this.score = score;
+        recipe.updateRatingDelta(this.score);
     }
 
     public void validateRatingRange(Integer rating){

--- a/backend/src/main/java/org/youcancook/gobong/domain/recipe/controller/RecipeController.java
+++ b/backend/src/main/java/org/youcancook/gobong/domain/recipe/controller/RecipeController.java
@@ -7,7 +7,10 @@ import org.springframework.web.bind.annotation.*;
 import org.youcancook.gobong.domain.recipe.dto.request.CreateRecipeRequest;
 import org.youcancook.gobong.domain.recipe.dto.request.UpdateRecipeRequest;
 import org.youcancook.gobong.domain.recipe.dto.response.CreateRecipeResponse;
+import org.youcancook.gobong.domain.recipe.dto.response.GetRecipeResponse;
+import org.youcancook.gobong.domain.recipe.service.GetRecipeService;
 import org.youcancook.gobong.domain.recipe.service.RecipeService;
+import org.youcancook.gobong.domain.recipedetail.service.RecipeDetailService;
 import org.youcancook.gobong.global.resolver.LoginUserId;
 
 @RestController
@@ -16,11 +19,14 @@ import org.youcancook.gobong.global.resolver.LoginUserId;
 public class RecipeController {
 
     private final RecipeService recipeService;
+    private final RecipeDetailService recipeDetailService;
+    private final GetRecipeService getRecipeService;
 
     @PostMapping
     public ResponseEntity<CreateRecipeResponse> createRecipe(@LoginUserId Long userId,
                                                              @RequestBody @Valid CreateRecipeRequest request){
         CreateRecipeResponse response = recipeService.createRecipe(userId, request);
+        recipeDetailService.uploadRecipeDetails(response.getId(), request.getRecipeDetails());
         return ResponseEntity.ok(response);
     }
 
@@ -28,6 +34,7 @@ public class RecipeController {
     public ResponseEntity<Void> updateRecipe(@LoginUserId Long userId,
                                              @RequestBody @Valid UpdateRecipeRequest request){
         recipeService.updateRecipe(userId, request);
+        recipeDetailService.uploadRecipeDetails(request.getRecipeId(), request.getRecipeDetails());
         return ResponseEntity.ok().build();
     }
 
@@ -37,4 +44,11 @@ public class RecipeController {
         recipeService.deleteRecipe(userId, recipeId);
         return ResponseEntity.ok().build();
     }
+
+    @GetMapping("{recipeId}")
+    public ResponseEntity<GetRecipeResponse> getRecipe(@LoginUserId Long userId, @PathVariable Long recipeId){
+        GetRecipeResponse response = getRecipeService.getRecipe(userId, recipeId);
+        return ResponseEntity.ok(response);
+    }
+
 }

--- a/backend/src/main/java/org/youcancook/gobong/domain/recipe/dto/recipeDto/RecipeDto.java
+++ b/backend/src/main/java/org/youcancook/gobong/domain/recipe/dto/recipeDto/RecipeDto.java
@@ -1,0 +1,37 @@
+package org.youcancook.gobong.domain.recipe.dto.recipeDto;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.youcancook.gobong.domain.recipe.entity.Cookware;
+import org.youcancook.gobong.domain.recipe.entity.Recipe;
+
+import java.util.Arrays;
+import java.util.List;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class RecipeDto {
+
+    private Long id;
+    private Long authorId;
+    private String authorName;
+    private String title;
+    private String introduction;
+    private List<String> ingredients;
+    private String difficulty;
+    private String thumbnailURL;
+    private List<String> cookwares;
+    private int totalCookTimeInSeconds;
+    private int totalBookmarkCount;
+    private Double averageRating;
+
+    public static RecipeDto from(Recipe recipe){
+        return new RecipeDto(recipe.getId(), recipe.getUser().getId(), recipe.getUser().getNickname(), recipe.getTitle(),
+                recipe.getIntroduction(), Arrays.stream(recipe.getIngredients().split(",")).toList(),
+                recipe.getDifficulty().getDescription(), recipe.getThumbnailURL(), Cookware.bitToList(recipe.getCookwares()),
+                recipe.getTotalCookTimeInSeconds(), recipe.getTotalBookmarkCount(), recipe.getAverageRating());
+    }
+}

--- a/backend/src/main/java/org/youcancook/gobong/domain/recipe/dto/request/CreateRecipeRequest.java
+++ b/backend/src/main/java/org/youcancook/gobong/domain/recipe/dto/request/CreateRecipeRequest.java
@@ -2,6 +2,7 @@ package org.youcancook.gobong.domain.recipe.dto.request;
 
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.ToString;
@@ -24,6 +25,7 @@ public class CreateRecipeRequest {
     private String difficulty;
     private String thumbnailURL;
 
+    @NotNull(message = "단계별 레시피는 필수 항목입니다.")
     private List<@Valid UploadRecipeDetailRequest> recipeDetails;
 
 }

--- a/backend/src/main/java/org/youcancook/gobong/domain/recipe/dto/response/GetRecipeResponse.java
+++ b/backend/src/main/java/org/youcancook/gobong/domain/recipe/dto/response/GetRecipeResponse.java
@@ -1,0 +1,22 @@
+package org.youcancook.gobong.domain.recipe.dto.response;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.youcancook.gobong.domain.recipedetail.dto.response.GetRecipeDetailResponse;
+
+import java.util.List;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class GetRecipeResponse {
+
+    private Long id;
+    private GetRecipeSummaryResponse summary;
+    private String introduction;
+    private List<String> ingredients;
+    private List<GetRecipeDetailResponse> recipeDetails;
+
+}

--- a/backend/src/main/java/org/youcancook/gobong/domain/recipe/dto/response/GetRecipeSummaryResponse.java
+++ b/backend/src/main/java/org/youcancook/gobong/domain/recipe/dto/response/GetRecipeSummaryResponse.java
@@ -1,0 +1,24 @@
+package org.youcancook.gobong.domain.recipe.dto.response;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class GetRecipeSummaryResponse {
+
+    private Long id;
+    private String thumbnailURL;
+    private RecipeAuthorResponse author;
+    private int totalBookmarkCount;
+    private int totalCookTimeInSeconds;
+    private List<String> cookwares;
+    private String difficulty;
+    private Double averageRating;
+
+}

--- a/backend/src/main/java/org/youcancook/gobong/domain/recipe/dto/response/RecipeAuthorResponse.java
+++ b/backend/src/main/java/org/youcancook/gobong/domain/recipe/dto/response/RecipeAuthorResponse.java
@@ -1,0 +1,17 @@
+package org.youcancook.gobong.domain.recipe.dto.response;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class RecipeAuthorResponse {
+
+    private Long id;
+    private String nickname;
+    private boolean isFollowing;
+    private boolean isMyself;
+}

--- a/backend/src/main/java/org/youcancook/gobong/domain/recipe/entity/Cookware.java
+++ b/backend/src/main/java/org/youcancook/gobong/domain/recipe/entity/Cookware.java
@@ -2,6 +2,10 @@ package org.youcancook.gobong.domain.recipe.entity;
 
 import lombok.Getter;
 
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
 @Getter
 public enum Cookware {
     MICROWAVE(0), AIR_FRYER(1), OVEN(2), GAS_RANGE(3),
@@ -14,6 +18,11 @@ public enum Cookware {
         this.value = 1L << power;
     }
 
-
+    public static List<String> bitToList(long cookwaresBit){
+        return Stream.of(Cookware.values())
+                .filter(cookware -> (cookware.value & cookwaresBit) != 0)
+                .map(Enum::name)
+                .collect(Collectors.toList());
+    }
 
 }

--- a/backend/src/main/java/org/youcancook/gobong/domain/recipe/entity/Recipe.java
+++ b/backend/src/main/java/org/youcancook/gobong/domain/recipe/entity/Recipe.java
@@ -6,11 +6,7 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.youcancook.gobong.domain.BaseTime.BaseTime;
-import org.youcancook.gobong.domain.rating.entity.Rating;
 import org.youcancook.gobong.domain.user.entity.User;
-
-import java.util.ArrayList;
-import java.util.List;
 
 @Entity
 @Getter
@@ -40,14 +36,11 @@ public class Recipe extends BaseTime {
 
     private String thumbnailURL;
 
-    @Column(nullable = false)
-    private Long cookwares;
-
-    @Column(nullable = false)
-    private Integer totalCookTimeInSeconds;
-
-    @OneToMany(mappedBy = "recipe")
-    private List<Rating> rating = new ArrayList<>();
+    private long cookwares;
+    private int totalBookmarkCount;
+    private int totalCookTimeInSeconds;
+    private int totalRating;
+    private int totalRatedNum;
 
     @Builder
     public Recipe(User user, String title, String introduction, String ingredients, Difficulty difficulty,
@@ -60,17 +53,12 @@ public class Recipe extends BaseTime {
         this.thumbnailURL = thumbnailURL;
         cookwares = 0L;
         totalCookTimeInSeconds = 0;
+        totalBookmarkCount = 0;
     }
 
-    public void addRating(Rating rating){
-        this.rating.add(rating);
-    }
-
-    public double getAverageRating(){
-        return rating.stream()
-                .mapToDouble(Rating::getScore)
-                .average()
-                .orElse(0.0);
+    public Double getAverageRating(){
+        if (totalRatedNum == 0) return null;
+        return (double) totalRating / (double) totalRatedNum;
     }
 
     public void updateProperties(String title, String introduction, String ingredients,
@@ -93,5 +81,25 @@ public class Recipe extends BaseTime {
     public void clearDetails() {
         this.cookwares = 0L;
         this.totalCookTimeInSeconds = 0;
+    }
+
+    public void updateRatingDelta(int delta) {
+        this.totalRating += delta;
+    }
+
+    public void increaseTotalRatedNum(){
+        this.totalRatedNum++;
+    }
+
+    public void decreaseTotalRatedNum(){
+        this.totalRatedNum--;
+    }
+
+    public void increaseBookmarkCount() {
+        this.totalBookmarkCount++;
+    }
+
+    public void decreaseBookmarkCount(){
+        this.totalBookmarkCount--;
     }
 }

--- a/backend/src/main/java/org/youcancook/gobong/domain/recipe/repository/RecipeRepository.java
+++ b/backend/src/main/java/org/youcancook/gobong/domain/recipe/repository/RecipeRepository.java
@@ -1,7 +1,16 @@
 package org.youcancook.gobong.domain.recipe.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.youcancook.gobong.domain.recipe.entity.Recipe;
 
+import java.util.Optional;
+
 public interface RecipeRepository extends JpaRepository<Recipe, Long> {
+
+    @Query("SELECT r FROM Recipe r " +
+            "JOIN FETCH RecipeDetail rd ON rd.recipe.id = r.id " +
+            "JOIN FETCH r.user u " +
+            "WHERE r.id =:recipeId")
+    Optional<Recipe> fetchFindById(Long recipeId);
 }

--- a/backend/src/main/java/org/youcancook/gobong/domain/recipe/service/GetRecipeService.java
+++ b/backend/src/main/java/org/youcancook/gobong/domain/recipe/service/GetRecipeService.java
@@ -1,0 +1,57 @@
+package org.youcancook.gobong.domain.recipe.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.youcancook.gobong.domain.follow.service.FollowService;
+import org.youcancook.gobong.domain.recipe.dto.recipeDto.RecipeDto;
+import org.youcancook.gobong.domain.recipe.dto.response.GetRecipeResponse;
+import org.youcancook.gobong.domain.recipe.dto.response.GetRecipeSummaryResponse;
+import org.youcancook.gobong.domain.recipe.dto.response.RecipeAuthorResponse;
+import org.youcancook.gobong.domain.recipe.entity.Recipe;
+import org.youcancook.gobong.domain.recipe.exception.RecipeNotFoundException;
+import org.youcancook.gobong.domain.recipe.repository.RecipeRepository;
+import org.youcancook.gobong.domain.recipedetail.dto.response.GetRecipeDetailResponse;
+import org.youcancook.gobong.domain.recipedetail.service.RecipeDetailService;
+
+import java.util.List;
+import java.util.Objects;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class GetRecipeService {
+
+    private final RecipeService recipeService;
+    private final FollowService followService;
+    private final RecipeDetailService recipeDetailService;
+    private final RecipeRepository recipeRepository;
+
+    public GetRecipeResponse getRecipe(Long userId, Long recipeId){
+        Recipe recipe = recipeRepository.fetchFindById(recipeId).orElseThrow(RecipeNotFoundException::new);
+        RecipeDto recipeDto = RecipeDto.from(recipe);
+        List<GetRecipeDetailResponse> recipeDetails = recipeDetailService.getRecipeDetails(recipe);
+        GetRecipeSummaryResponse summaryResponse = getSummary(userId, recipeDto);
+
+        return new GetRecipeResponse(recipeDto.getId(), summaryResponse,
+                recipeDto.getIntroduction(), recipeDto.getIngredients(), recipeDetails);
+    }
+
+    public GetRecipeSummaryResponse getSummary(Long userId, RecipeDto recipeDto){
+        RecipeAuthorResponse authorResponse = getAuthor(userId, recipeDto);
+        return new GetRecipeSummaryResponse(
+                recipeDto.getId(), recipeDto.getThumbnailURL(), authorResponse,
+                recipeDto.getTotalBookmarkCount(), recipeDto.getTotalCookTimeInSeconds(), recipeDto.getCookwares(),
+                recipeDto.getDifficulty(), recipeDto.getAverageRating()
+        );
+    }
+
+    public RecipeAuthorResponse getAuthor(Long userId, RecipeDto recipeDto){
+        Long authorId = recipeDto.getAuthorId();
+        String authorNickname = recipeDto.getAuthorName();
+        boolean isFollowing = followService.isFollowing(userId, authorId);
+        boolean isMyself = Objects.equals(userId, authorId);
+
+        return new RecipeAuthorResponse(authorId, authorNickname, isFollowing, isMyself);
+    }
+}

--- a/backend/src/main/java/org/youcancook/gobong/domain/recipedetail/dto/response/GetRecipeDetailResponse.java
+++ b/backend/src/main/java/org/youcancook/gobong/domain/recipedetail/dto/response/GetRecipeDetailResponse.java
@@ -1,0 +1,24 @@
+package org.youcancook.gobong.domain.recipedetail.dto.response;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class GetRecipeDetailResponse {
+
+    private Long id;
+
+    private String content;
+    private String imageURL;
+    private int cookTimeInSeconds;
+    private List<String> cookwares;
+
+    private int step;
+
+}

--- a/backend/src/main/java/org/youcancook/gobong/domain/recipedetail/repository/RecipeDetailRepository.java
+++ b/backend/src/main/java/org/youcancook/gobong/domain/recipedetail/repository/RecipeDetailRepository.java
@@ -11,6 +11,9 @@ public interface RecipeDetailRepository extends JpaRepository<RecipeDetail, Long
 
     List<RecipeDetail> findAllByRecipeId(Long recipeId);
 
+    @Query("SELECT rd FROM RecipeDetail rd WHERE rd.recipe.id =:recipeId ORDER BY rd.step ASC")
+    List<RecipeDetail> findAllByRecipeIdOrderByStep(Long recipeId);
+
     @Modifying(clearAutomatically = true, flushAutomatically = true)
     @Query("DELETE FROM RecipeDetail as rd where rd.recipe.id =:recipeId")
     void deleteAllByRecipeId(Long recipeId);

--- a/backend/src/test/java/org/youcancook/gobong/domain/bookmarkrecipe/service/BookmarkRecipeServiceTest.java
+++ b/backend/src/test/java/org/youcancook/gobong/domain/bookmarkrecipe/service/BookmarkRecipeServiceTest.java
@@ -56,6 +56,7 @@ class BookmarkRecipeServiceTest {
         User user = User.builder().nickname("쩝쩝박사").oAuthProvider(OAuthProvider.GOOGLE).oAuthId("123").build();
         Recipe recipe = Recipe.builder().title("주먹밥").difficulty(Difficulty.EASY).build();
         userRepository.save(user);
+        recipe.increaseBookmarkCount();
         recipeRepository.save(recipe);
 
         BookmarkRecipe bookmarkRecipe = new BookmarkRecipe(user, recipe);
@@ -75,9 +76,12 @@ class BookmarkRecipeServiceTest {
     @DisplayName("존재하지 않는 북마크를 삭제하려고 하면 예외를 발생한다.")
     public void notFoundTest(){
         User user = User.builder().nickname("쩝쩝박사").oAuthProvider(OAuthProvider.GOOGLE).oAuthId("123").build();
+        Recipe recipe = Recipe.builder().title("주먹밥").difficulty(Difficulty.EASY).build();
         userRepository.save(user);
+        Long recipeId = recipeRepository.save(recipe).getId();
+
         assertThrows(BookmarkRecipeNotFoundException.class, ()->
-                bookmarkRecipeService.removeBookmark(user.getId(), 99L));
+                bookmarkRecipeService.removeBookmark(user.getId(), recipeId));
     }
 
     @Test

--- a/backend/src/test/java/org/youcancook/gobong/domain/bookmarkrecipe/service/BookmarkRecipeServiceTest.java
+++ b/backend/src/test/java/org/youcancook/gobong/domain/bookmarkrecipe/service/BookmarkRecipeServiceTest.java
@@ -1,6 +1,5 @@
 package org.youcancook.gobong.domain.bookmarkrecipe.service;
 
-import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -19,6 +18,7 @@ import org.youcancook.gobong.global.util.service.ServiceTest;
 
 import java.util.List;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 @ServiceTest
@@ -42,8 +42,12 @@ class BookmarkRecipeServiceTest {
 
         bookmarkRecipeService.addBookmark(user.getId(), recipe.getId());
         List<BookmarkRecipe> actual = bookmarkRecipeRepository.findAll();
-        Assertions.assertThat(actual).hasSize(1);
-        Assertions.assertThat(actual.get(0).getUser().getId()).isEqualTo(user.getId());
+        assertThat(actual).hasSize(1);
+        assertThat(actual.get(0).getUser().getId()).isEqualTo(user.getId());
+
+        List<Recipe> recipeActual = recipeRepository.findAll();
+        assertThat(recipeActual).hasSize(1);
+        assertThat(recipeActual.get(0).getTotalBookmarkCount()).isEqualTo(1);
     }
 
     @Test
@@ -60,7 +64,11 @@ class BookmarkRecipeServiceTest {
         bookmarkRecipeService.removeBookmark(user.getId(), recipe.getId());
 
         List<BookmarkRecipe> actual = bookmarkRecipeRepository.findAll();
-        Assertions.assertThat(actual).isEmpty();
+        assertThat(actual).isEmpty();
+
+        List<Recipe> recipeActual = recipeRepository.findAll();
+        assertThat(recipeActual).hasSize(1);
+        assertThat(recipeActual.get(0).getTotalBookmarkCount()).isEqualTo(0);
     }
 
     @Test

--- a/backend/src/test/java/org/youcancook/gobong/domain/follow/service/FollowServiceTest.java
+++ b/backend/src/test/java/org/youcancook/gobong/domain/follow/service/FollowServiceTest.java
@@ -124,6 +124,36 @@ class FollowServiceTest {
         assertThrows(NotFollowingException.class, () -> followService.unfollow(follower.getId(), followee.getId()));
     }
 
+    @Test
+    @DisplayName("팔로우하지 않았다면, 여부를 정상적으로 리턴한다.")
+    public void testNotFollowing(){
+        User follower = createTestUser(1L);
+        User followee = createTestUser(2L);
+        when(userRepository.findById(follower.getId()))
+                .thenReturn(Optional.of(follower));
+        when(userRepository.findById(followee.getId()))
+                .thenReturn(Optional.of(followee));
+        when(followRepository.existsByFollowerAndFollowee(follower, followee))
+                .thenReturn(false);
+
+        assertThat(followService.isFollowing(follower.getId(), followee.getId())).isFalse();
+    }
+
+    @Test
+    @DisplayName("팔로우했다면, 여부를 정상적으로 출력한다.")
+    public void testFollowing(){
+        User follower = createTestUser(1L);
+        User followee = createTestUser(2L);
+        when(userRepository.findById(follower.getId()))
+                .thenReturn(Optional.of(follower));
+        when(userRepository.findById(followee.getId()))
+                .thenReturn(Optional.of(followee));
+        when(followRepository.existsByFollowerAndFollowee(follower, followee))
+                .thenReturn(true);
+
+        assertThat(followService.isFollowing(follower.getId(), followee.getId())).isTrue();
+    }
+
     private User createTestUser(Long userId) {
         User user = User.builder()
                 .nickname("nickname" + userId)

--- a/backend/src/test/java/org/youcancook/gobong/domain/rating/service/RatingServiceTest.java
+++ b/backend/src/test/java/org/youcancook/gobong/domain/rating/service/RatingServiceTest.java
@@ -1,6 +1,5 @@
 package org.youcancook.gobong.domain.rating.service;
 
-import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -17,8 +16,8 @@ import org.youcancook.gobong.domain.user.repository.UserRepository;
 import org.youcancook.gobong.global.util.service.ServiceTest;
 
 import java.util.List;
-import java.util.Optional;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 
@@ -40,19 +39,29 @@ class RatingServiceTest {
                 .oAuthProvider(OAuthProvider.GOOGLE).build();
         User user2 = User.builder().nickname("쩝쩝박사123").oAuthId("1234")
                 .oAuthProvider(OAuthProvider.GOOGLE).build();
+        User user3 = User.builder().nickname("쩝쩝학사").oAuthId("12345")
+                .oAuthProvider(OAuthProvider.GOOGLE).build();
         Recipe recipe = Recipe.builder().user(user)
                 .title("주먹밥").difficulty(Difficulty.EASY).build();
 
         userRepository.save(user);
         Long user2Id = userRepository.save(user2).getId();
+        Long user3Id = userRepository.save(user3).getId();
 
         Long recipeId = recipeRepository.save(recipe).getId();
 
         ratingService.createRating(user2Id, recipeId, 3);
+        ratingService.createRating(user3Id, recipeId, 5);
+
         List<Rating> actual = ratingRepository.findAll();
 
-        Assertions.assertThat(actual).isNotEmpty();
-        Assertions.assertThat(actual.get(0).getScore()).isEqualTo(3);
+        assertThat(actual).isNotEmpty();
+        assertThat(actual.stream().mapToDouble(Rating::getScore).average().orElse(0.0)).isEqualTo(4.0);
+
+        List<Recipe> recipeActual = recipeRepository.findAll();
+        assertThat(recipeActual).isNotEmpty();
+        assertThat(recipeActual.get(0).getAverageRating()).isEqualTo(4.0);
+
     }
 
     @Test
@@ -62,22 +71,30 @@ class RatingServiceTest {
                 .oAuthProvider(OAuthProvider.GOOGLE).build();
         User user2 = User.builder().nickname("쩝쩝박사123").oAuthId("1234")
                 .oAuthProvider(OAuthProvider.GOOGLE).build();
+        User user3 = User.builder().nickname("쩝쩝학사").oAuthId("12345")
+                .oAuthProvider(OAuthProvider.GOOGLE).build();
         Recipe recipe = Recipe.builder().user(user)
                 .title("주먹밥").difficulty(Difficulty.EASY).build();
 
         userRepository.save(user);
         Long user2Id = userRepository.save(user2).getId();
+        Long user3Id = userRepository.save(user3).getId();
 
         Long recipeId = recipeRepository.save(recipe).getId();
 
-        Rating rating = new Rating(user2, recipe, 3);
-        Long ratingId = ratingRepository.save(rating).getId();
+        ratingService.createRating(user2Id, recipeId, 3);
+        ratingService.createRating(user3Id, recipeId, 5);
 
         ratingService.updateRating(user2Id, recipeId, 5);
-        Optional<Rating> actual = ratingRepository.findById(ratingId);
 
-        Assertions.assertThat(actual).isNotEmpty();
-        Assertions.assertThat(actual.get().getScore()).isEqualTo(5);
+        List<Rating> actual = ratingRepository.findAll();
+
+        assertThat(actual).isNotEmpty();
+        assertThat(actual.stream().mapToDouble(Rating::getScore).average().orElse(0.0)).isEqualTo(5.0);
+
+        List<Recipe> recipeActual = recipeRepository.findAll();
+        assertThat(recipeActual).isNotEmpty();
+        assertThat(recipeActual.get(0).getAverageRating()).isEqualTo(5.0);
     }
 
     @Test

--- a/backend/src/test/java/org/youcancook/gobong/domain/recipe/entity/CookwareTest.java
+++ b/backend/src/test/java/org/youcancook/gobong/domain/recipe/entity/CookwareTest.java
@@ -1,0 +1,22 @@
+package org.youcancook.gobong.domain.recipe.entity;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class CookwareTest {
+    @Test
+    @DisplayName("조리기구 비트를 조리기구 리스트로 변환한다.")
+    public void convertBitToCookwares(){
+        long cookwareBit = Cookware.OVEN.getValue() | Cookware.MICROWAVE.getValue() | Cookware.ELECTRIC_KETTLE.getValue();
+        System.out.println(cookwareBit);
+        List<String> actual = Cookware.bitToList(cookwareBit);
+
+        assertThat(actual).hasSize(3);
+        assertThat(actual).hasSameElementsAs(
+                List.of(Cookware.OVEN.name(), Cookware.MICROWAVE.name(), Cookware.ELECTRIC_KETTLE.name()));
+    }
+}

--- a/backend/src/test/java/org/youcancook/gobong/domain/recipe/service/RecipeAcceptanceTest.java
+++ b/backend/src/test/java/org/youcancook/gobong/domain/recipe/service/RecipeAcceptanceTest.java
@@ -95,4 +95,22 @@ public class RecipeAcceptanceTest extends AcceptanceTest {
                 .statusCode(HttpStatus.OK.value())
                 .extract();
     }
+
+    @Test
+    @DisplayName("레시피 단건 조회를 성공한다.")
+    public void getRecipe(){
+        String accessToken = AcceptanceUtils.signUpAndGetToken("쩝쩝박사", "KAKAO", "123");
+        CreateRecipeRequest request = new CreateRecipeRequest("주먹밥", "쉽게 만드는 주먹밥", List.of("밥", "김"), "쉬워요", null, List.of(
+                new UploadRecipeDetailRequest("소금간을 해 주세요", null, 30, 1L),
+                new UploadRecipeDetailRequest("주먹을 쥐어 밥을 뭉쳐주세요", null, 15, 2L)
+        ));
+        Long recipeId = AcceptanceUtils.createDummyRecipe(accessToken, request).as(CreateRecipeResponse.class).getId();
+
+        RestAssured.given().log().all()
+                .auth().oauth2(accessToken)
+                .when().get("/api/recipes/" + recipeId)
+                .then().log().all()
+                .statusCode(HttpStatus.OK.value())
+                .extract();
+    }
 }

--- a/backend/src/test/java/org/youcancook/gobong/domain/recipedetail/service/RecipeDetailServiceTest.java
+++ b/backend/src/test/java/org/youcancook/gobong/domain/recipedetail/service/RecipeDetailServiceTest.java
@@ -45,7 +45,7 @@ class RecipeDetailServiceTest {
         recipeRepository.save(recipe);
 
         String content = "밥을 비벼주세요";
-        recipeDetailService.uploadRecipeDetail(recipe, content, "",
+        recipeDetailService.uploadRecipeDetail(recipe.getId(), content, "",
                 30, 1L, 1);
         List<RecipeDetail> actual = recipeDetailRepository.findAll();
 
@@ -71,6 +71,11 @@ class RecipeDetailServiceTest {
 
         List<RecipeDetail> actual = recipeDetailRepository.findAllByRecipeId(recipeId);
         assertThat(actual).hasSize(2);
+
+        List<Recipe> actualRecipe = recipeRepository.findAll();
+        assertThat(actualRecipe).isNotEmpty();
+        assertThat(actualRecipe.get(0).getTotalCookTimeInSeconds()).isEqualTo(45);
+        assertThat(actualRecipe.get(0).getCookwares()).isEqualTo(3L);
     }
 
     @Test
@@ -132,8 +137,8 @@ class RecipeDetailServiceTest {
         List<Recipe> recipeActual = recipeRepository.findAll();
         assertThat(recipeActual).hasSize(1);
 
-        assertThat(recipe.getTotalCookTimeInSeconds()).isEqualTo(45);
-        assertThat(recipe.getCookwares()).isEqualTo(5L);
+        assertThat(recipeActual.get(0).getTotalCookTimeInSeconds()).isEqualTo(45);
+        assertThat(recipeActual.get(0).getCookwares()).isEqualTo(5L);
     }
 
     @AfterEach


### PR DESCRIPTION
## 개요 🧾
<!-- 이곳에 PR의 내용을 간단하게 작성해주세요. -->
API `/api/recipes/{recipeId}` GET
레시피 단건 조회를 구현했습니다. 현재 쿼리는 세개 나갑니다. (Recipe 전체, 단계별 레시피 정보, 해당 글쓴이와의 팔로우 여부)

서비스에서 다른 서비스를 부르는게 애매하다고 생각했지만 트랜잭션으로 묶을 필요가 있었기에, 그 두 개의 서비스를 묶은 서비스를 만들었습니다. 컨트롤러는 묶은 서비스를 호출하며, 같은 트랜잭션 안에 존재하게 됩니다.

초기 도메인 설계의 중요성을 뼈저리게 느끼고 있지만 시간이 없다는게 참 아쉽네요

## 변경사항 🛠
<!-- 이곳에 코드 변경 사항이나 추가된 사항에 대해서 작성해주세요. -->

Recipe에서 참조할 수 있도록 한 여러 연관관계를 제거했습니다. (사용하지 않아서)
Recipe에 몇가지 필드를 추가해 추가적인 쿼리를 나오지 않게 했습니다.


## 주의사항 ⚠
<!-- 이곳에 리뷰어에게 할 말이나, 주의해야 하는 점에 대해서 작성해 주세요 -->
코드가 많이 바뀌었고, 테스트를 추가했으나 생각하지 못한 엣지 케이스 테스트가 있을 수 있습니다. 확인해 주세요.

동시성 등을 고려해보아야 할 것 같습니다.. 이건 나중에 생각해도 될 것 같아요
이 경우 실제 합산한 값과 DB에 저장된 값이 다를 수 있는데, 일정 주기마다 이를 동기화하는 방법도 괜찮을 것 같습니다. 어떤게 가장 좋을지는 또 회의해봐야 알겠네요

현재 같은 레시피 추가 컨트롤러 안에 다른 트랜잭션으로 묶인 두 서비스가 또 있습니다. 이것도 합쳐야할 것 같은데, 의견은 어떠신가요? (레시피 추가, 레시피 안에 단계별 레시피 추가)
