### PR TITLE
feat: 유저 정보 조회, 닉네임과 프로필 사진 변경 api

### DIFF
--- a/backend/src/main/java/org/youcancook/gobong/domain/user/controller/UserController.java
+++ b/backend/src/main/java/org/youcancook/gobong/domain/user/controller/UserController.java
@@ -9,11 +9,15 @@ import org.youcancook.gobong.domain.authentication.service.TemporaryTokenService
 import org.youcancook.gobong.domain.user.dto.SignupDto;
 import org.youcancook.gobong.domain.user.dto.request.LoginRequest;
 import org.youcancook.gobong.domain.user.dto.request.SignupRequest;
+import org.youcancook.gobong.domain.user.dto.request.UpdateUserInformationRequest;
 import org.youcancook.gobong.domain.user.dto.response.LoginResponse;
 import org.youcancook.gobong.domain.user.dto.response.SignupResponse;
 import org.youcancook.gobong.domain.user.dto.response.TemporaryTokenIssueResponse;
+import org.youcancook.gobong.domain.user.dto.response.UserInformationResponse;
+import org.youcancook.gobong.domain.user.service.UserInformationService;
 import org.youcancook.gobong.domain.user.service.UserLoginService;
 import org.youcancook.gobong.domain.user.service.UserSignupService;
+import org.youcancook.gobong.global.resolver.LoginUserId;
 
 @RestController
 @RequiredArgsConstructor
@@ -23,6 +27,7 @@ public class UserController {
     private final TemporaryTokenService temporaryTokenService;
     private final UserLoginService userLoginService;
     private final UserSignupService userSignupService;
+    private final UserInformationService userInformationService;
 
     @PostMapping("temporary-token")
     @ResponseStatus(HttpStatus.CREATED)
@@ -46,5 +51,18 @@ public class UserController {
         SignupResponse response = userSignupService.signup(SignupDto.from(request));
         temporaryTokenService.deleteTemporaryToken(temporaryTokenId);
         return ResponseEntity.ok(response);
+    }
+
+    @GetMapping
+    public ResponseEntity<UserInformationResponse> getUserInformation(@LoginUserId Long loginUserId) {
+        UserInformationResponse response = userInformationService.getUserInformation(loginUserId);
+        return ResponseEntity.ok(response);
+    }
+
+    @PatchMapping
+    public ResponseEntity<Void> updateUserInformation(@LoginUserId Long loginUserId,
+                                                      @RequestBody @Valid UpdateUserInformationRequest request) {
+        userInformationService.updateInformation(loginUserId, request.getNickname(), request.getProfileImageURL());
+        return ResponseEntity.ok().build();
     }
 }

--- a/backend/src/main/java/org/youcancook/gobong/domain/user/dto/request/UpdateUserInformationRequest.java
+++ b/backend/src/main/java/org/youcancook/gobong/domain/user/dto/request/UpdateUserInformationRequest.java
@@ -1,0 +1,17 @@
+package org.youcancook.gobong.domain.user.dto.request;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.youcancook.gobong.global.validation.annotation.UserNickname;
+
+@Getter
+@NoArgsConstructor(access = lombok.AccessLevel.PRIVATE)
+@AllArgsConstructor
+public class UpdateUserInformationRequest {
+
+    @UserNickname
+    private String nickname;
+
+    private String profileImageURL;
+}

--- a/backend/src/main/java/org/youcancook/gobong/domain/user/dto/response/UserInformationResponse.java
+++ b/backend/src/main/java/org/youcancook/gobong/domain/user/dto/response/UserInformationResponse.java
@@ -1,0 +1,28 @@
+package org.youcancook.gobong.domain.user.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import org.youcancook.gobong.domain.user.entity.User;
+
+@Getter
+@Builder
+@AllArgsConstructor
+public class UserInformationResponse {
+    private Long id;
+    private String nickname;
+    private String profileImageURL;
+
+    @JsonProperty("oAuthProvider")
+    private String oauthProvider;
+
+    public static UserInformationResponse from(User user) {
+        return UserInformationResponse.builder()
+                .id(user.getId())
+                .nickname(user.getNickname())
+                .profileImageURL(user.getProfileImageURL())
+                .oauthProvider(user.getOAuthProvider().name())
+                .build();
+    }
+}

--- a/backend/src/main/java/org/youcancook/gobong/domain/user/entity/User.java
+++ b/backend/src/main/java/org/youcancook/gobong/domain/user/entity/User.java
@@ -46,4 +46,9 @@ public class User {
         this.oAuthProvider = oAuthProvider;
         this.profileImageURL = profileImageURL;
     }
+
+    public void updateNicknameAndProfileImageURL(String nickname, String profileImageURL) {
+        this.nickname = nickname;
+        this.profileImageURL = profileImageURL;
+    }
 }

--- a/backend/src/main/java/org/youcancook/gobong/domain/user/service/UserInformationService.java
+++ b/backend/src/main/java/org/youcancook/gobong/domain/user/service/UserInformationService.java
@@ -1,0 +1,40 @@
+package org.youcancook.gobong.domain.user.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.youcancook.gobong.domain.user.dto.response.UserInformationResponse;
+import org.youcancook.gobong.domain.user.entity.User;
+import org.youcancook.gobong.domain.user.exception.DuplicationNicknameException;
+import org.youcancook.gobong.domain.user.exception.UserNotFoundException;
+import org.youcancook.gobong.domain.user.repository.UserRepository;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class UserInformationService {
+
+    private final UserRepository userRepository;
+
+    public UserInformationResponse getUserInformation(Long userId) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(UserNotFoundException::new);
+        return UserInformationResponse.from(user);
+    }
+
+    @Transactional
+    public void updateInformation(Long userId, String nickname, String profileImageURL) {
+        validateDuplicateNickname(nickname);
+
+        User user = userRepository.findById(userId)
+                .orElseThrow(UserNotFoundException::new);
+        user.updateNicknameAndProfileImageURL(nickname, profileImageURL);
+    }
+
+    private void validateDuplicateNickname(String nickname) {
+        if (userRepository.existsByNickname(nickname)) {
+            throw new DuplicationNicknameException();
+        }
+    }
+
+}

--- a/backend/src/test/java/org/youcancook/gobong/domain/user/service/UserInformationServiceTest.java
+++ b/backend/src/test/java/org/youcancook/gobong/domain/user/service/UserInformationServiceTest.java
@@ -1,0 +1,93 @@
+package org.youcancook.gobong.domain.user.service;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.youcancook.gobong.domain.user.dto.response.UserInformationResponse;
+import org.youcancook.gobong.domain.user.entity.OAuthProvider;
+import org.youcancook.gobong.domain.user.entity.User;
+import org.youcancook.gobong.domain.user.exception.DuplicationNicknameException;
+import org.youcancook.gobong.domain.user.repository.UserRepository;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class UserInformationServiceTest {
+
+    @InjectMocks
+    private UserInformationService userInformationService;
+
+    @Mock
+    private UserRepository userRepository;
+
+    @Test
+    @DisplayName("회원정보 조회")
+    void checkInformation() {
+        // given
+        User user = createTestUser();
+        ReflectionTestUtils.setField(user, "id", 1L);
+        when(userRepository.findById(user.getId()))
+                .thenReturn(Optional.of(user));
+
+        // when
+        UserInformationResponse result = userInformationService.getUserInformation(user.getId());
+
+        // then
+        assertThat(result.getId()).isEqualTo(user.getId());
+        assertThat(result.getNickname()).isEqualTo(user.getNickname());
+        assertThat(result.getOauthProvider()).isEqualTo(user.getOAuthProvider().name());
+        assertThat(result.getProfileImageURL()).isEqualTo(user.getProfileImageURL());
+    }
+
+    @Test
+    @DisplayName("회원정보 수정 성공")
+    void updateInformationSuccess() {
+        // given
+        String newNickname = "newNickname";
+        String newProfileImageURL = "newProfileImageURL";
+        User user = createTestUser();
+        Long userId = 1L;
+        when(userRepository.existsByNickname(newNickname))
+                .thenReturn(false);
+        when(userRepository.findById(userId))
+                .thenReturn(Optional.of(user));
+
+        // when
+        userInformationService.updateInformation(userId, newNickname, newProfileImageURL);
+
+        // then
+        assertThat(user.getNickname()).isEqualTo(newNickname);
+        assertThat(user.getProfileImageURL()).isEqualTo(newProfileImageURL);
+    }
+
+    @Test
+    @DisplayName("회원정보 수정 실패 - 중복된 닉네임")
+    void updateInformationFailByDuplicatedNickname() {
+        // given
+        String newNickname = "newNickname";
+        when(userRepository.existsByNickname(newNickname))
+                .thenReturn(true);
+
+        // expect
+        assertThrows(DuplicationNicknameException.class,
+                () -> userInformationService.updateInformation(1L, newNickname, "newProfileImageURL"));
+
+    }
+
+    private User createTestUser() {
+        return User.builder()
+                .nickname("nickname")
+                .oAuthProvider(OAuthProvider.KAKAO)
+                .oAuthId("oauthid")
+                .profileImageURL("profileImageURL")
+                .build();
+    }
+}


### PR DESCRIPTION
## 개요 🧾
유저 정보 조회, 닉네임과 프로필 사진 변경 api

## 변경사항 🛠
- 유저 정보 조회 API
  - URL : GET `api/users`
  - Response 예시
  ```json
  {
    "id": 4,
    "nickname": "nickname",
    "profileImageURL": "profileImageURL",
    "oAuthProvider": "KAKAO"
  }
  ```
- 닉네임과 프로필 사진 변경 API
  - URL : PATCH `api/users`
  - Request 예시
  ```json
  {
    "nickname": "newNick",
    "profileImageURL": "newProfileImageURL"
  }
  ```