### PR TITLE
feat: 레시피 피드 전체조회 구현

### DIFF
--- a/backend/src/main/java/org/youcancook/gobong/domain/recipe/controller/FeedController.java
+++ b/backend/src/main/java/org/youcancook/gobong/domain/recipe/controller/FeedController.java
@@ -1,0 +1,30 @@
+package org.youcancook.gobong.domain.recipe.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import org.youcancook.gobong.domain.recipe.dto.response.GetFeedResponse;
+import org.youcancook.gobong.domain.recipe.service.GetRecipeService;
+import org.youcancook.gobong.global.resolver.LoginUserId;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("api/feed")
+public class FeedController {
+
+    private final GetRecipeService getRecipeService;
+
+    @GetMapping("all")
+    public ResponseEntity<GetFeedResponse> getFeed(@LoginUserId Long userId,
+                                                   @RequestParam(name = "last", required = false) Long lastRecipeId,
+                                                   @RequestParam(name = "count", required = true) int count){
+        GetFeedResponse response = getRecipeService.getAllFeed(userId, lastRecipeId, count);
+        return ResponseEntity.ok(response);
+    }
+
+
+
+}

--- a/backend/src/main/java/org/youcancook/gobong/domain/recipe/dto/response/GetFeedResponse.java
+++ b/backend/src/main/java/org/youcancook/gobong/domain/recipe/dto/response/GetFeedResponse.java
@@ -1,0 +1,16 @@
+package org.youcancook.gobong.domain.recipe.dto.response;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class GetFeedResponse {
+    private List<GetRecipeSummaryResponse> feed;
+    private boolean hasNext;
+}

--- a/backend/src/main/java/org/youcancook/gobong/domain/recipe/dto/response/GetRecipeSummaryResponse.java
+++ b/backend/src/main/java/org/youcancook/gobong/domain/recipe/dto/response/GetRecipeSummaryResponse.java
@@ -13,6 +13,7 @@ import java.util.List;
 public class GetRecipeSummaryResponse {
 
     private Long id;
+    private String title;
     private String thumbnailURL;
     private RecipeAuthorResponse author;
     private int totalBookmarkCount;

--- a/backend/src/main/java/org/youcancook/gobong/domain/recipe/repository/RecipeRepository.java
+++ b/backend/src/main/java/org/youcancook/gobong/domain/recipe/repository/RecipeRepository.java
@@ -1,5 +1,7 @@
 package org.youcancook.gobong.domain.recipe.repository;
 
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.youcancook.gobong.domain.recipe.entity.Recipe;
@@ -13,4 +15,7 @@ public interface RecipeRepository extends JpaRepository<Recipe, Long> {
             "JOIN FETCH r.user u " +
             "WHERE r.id =:recipeId")
     Optional<Recipe> fetchFindById(Long recipeId);
+
+    @Query("SELECT r FROM Recipe r WHERE r.id <:recipeId")
+    Slice<Recipe> getChunkById(Long recipeId, PageRequest of);
 }

--- a/backend/src/test/java/org/youcancook/gobong/domain/recipe/service/GetRecipeServiceTest.java
+++ b/backend/src/test/java/org/youcancook/gobong/domain/recipe/service/GetRecipeServiceTest.java
@@ -1,0 +1,60 @@
+package org.youcancook.gobong.domain.recipe.service;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.youcancook.gobong.domain.recipe.dto.response.GetFeedResponse;
+import org.youcancook.gobong.domain.recipe.entity.Difficulty;
+import org.youcancook.gobong.domain.recipe.entity.Recipe;
+import org.youcancook.gobong.domain.recipe.repository.RecipeRepository;
+import org.youcancook.gobong.domain.recipedetail.repository.RecipeDetailRepository;
+import org.youcancook.gobong.domain.user.entity.OAuthProvider;
+import org.youcancook.gobong.domain.user.entity.User;
+import org.youcancook.gobong.domain.user.repository.UserRepository;
+import org.youcancook.gobong.global.util.service.ServiceTest;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@ServiceTest
+class GetRecipeServiceTest {
+
+    @Autowired
+    RecipeRepository recipeRepository;
+    @Autowired
+    GetRecipeService getRecipeService;
+    @Autowired
+    UserRepository userRepository;
+    @Autowired
+    RecipeDetailRepository recipeDetailRepository;
+
+    @Test
+    public void getFeed(){
+        User user = new User("name", "abc", OAuthProvider.GOOGLE, null);
+        Long userId = userRepository.save(user).getId();
+
+        Recipe recipe1 = new Recipe(user,"주먹밥1", "주먹밥을 만들자", "밥", Difficulty.EASY, null);
+        Recipe recipe2 = new Recipe(user,"주먹밥2", "주먹밥을 만들자", "밥", Difficulty.EASY, null);
+        Recipe recipe3 = new Recipe(user,"주먹밥3", "주먹밥을 만들자", "밥", Difficulty.EASY, null);
+        Recipe recipe4 = new Recipe(user,"주먹밥4", "주먹밥을 만들자", "밥", Difficulty.EASY, null);
+
+        recipeRepository.save(recipe1);
+        recipeRepository.save(recipe2);
+        recipeRepository.save(recipe3);
+        Long lastId = recipeRepository.save(recipe4).getId();
+
+        List<Long> recipeIds = recipeRepository.findAll().stream().map(Recipe::getId).toList();
+
+        GetFeedResponse feedResponse = getRecipeService.getAllFeed(userId, null, 3);
+
+        assertThat(feedResponse.getFeed()).hasSize(3);
+        assertThat(feedResponse.isHasNext()).isTrue();
+
+        Long lastRecipeId = feedResponse.getFeed().get(2).getId();
+        GetFeedResponse actual = getRecipeService.getAllFeed(userId, lastRecipeId, 3);
+        assertThat(actual.getFeed()).hasSize(1);
+        assertThat(actual.isHasNext()).isFalse();
+
+    }
+
+}

--- a/backend/src/test/java/org/youcancook/gobong/domain/recipe/service/RecipeAcceptanceTest.java
+++ b/backend/src/test/java/org/youcancook/gobong/domain/recipe/service/RecipeAcceptanceTest.java
@@ -113,4 +113,24 @@ public class RecipeAcceptanceTest extends AcceptanceTest {
                 .statusCode(HttpStatus.OK.value())
                 .extract();
     }
+
+    @Test
+    public void getFeed(){
+        String accessToken = AcceptanceUtils.signUpAndGetToken("쩝쩝박사", "KAKAO", "123");
+        for(int i = 1; i <= 10; i++){
+            CreateRecipeRequest request = new CreateRecipeRequest("주먹밥", "1번 레시피", List.of("밥", "김"), "쉬워요", null, List.of(
+                    new UploadRecipeDetailRequest("소금간을 해 주세요", null, 30, List.of("MICROWAVE")),
+                    new UploadRecipeDetailRequest("주먹을 쥐어 밥을 뭉쳐주세요", null, 15, List.of("PAN"))
+            ));
+            AcceptanceUtils.createDummyRecipe(accessToken, request).as(CreateRecipeResponse.class);
+        }
+
+        RestAssured.given().log().all()
+                .auth().oauth2(accessToken)
+                .when().get("/api/recipes/feed?count=3")
+                .then().log().all()
+                .statusCode(HttpStatus.OK.value())
+                .extract();
+
+    }
 }

--- a/backend/src/test/java/org/youcancook/gobong/domain/recipe/service/RecipeAcceptanceTest.java
+++ b/backend/src/test/java/org/youcancook/gobong/domain/recipe/service/RecipeAcceptanceTest.java
@@ -115,6 +115,7 @@ public class RecipeAcceptanceTest extends AcceptanceTest {
     }
 
     @Test
+    @DisplayName("전체 피드를 조회한다.")
     public void getFeed(){
         String accessToken = AcceptanceUtils.signUpAndGetToken("쩝쩝박사", "KAKAO", "123");
         for(int i = 1; i <= 10; i++){
@@ -127,7 +128,7 @@ public class RecipeAcceptanceTest extends AcceptanceTest {
 
         RestAssured.given().log().all()
                 .auth().oauth2(accessToken)
-                .when().get("/api/recipes/feed?count=3")
+                .when().get("/api/feed/all?count=3")
                 .then().log().all()
                 .statusCode(HttpStatus.OK.value())
                 .extract();


### PR DESCRIPTION
## 개요 🧾
<!-- 이곳에 PR의 내용을 간단하게 작성해주세요. -->
API `/api/feed/all?last={lastRecipeId}&count={count}` GET
No-Offset 레시피 조회를 구현했습니다. 

## 주의사항 ⚠
<!-- 이곳에 리뷰어에게 할 말이나, 주의해야 하는 점에 대해서 작성해 주세요 -->
Slice가 잘 구현되었나 확인해주세요.