### PR TITLE
feat: 레시피 조회 시 글쓴이의 프로필사진 URL, 북마크 여부 response에 추가

### DIFF
--- a/backend/src/main/java/org/youcancook/gobong/domain/bookmarkrecipe/service/BookmarkRecipeService.java
+++ b/backend/src/main/java/org/youcancook/gobong/domain/bookmarkrecipe/service/BookmarkRecipeService.java
@@ -45,4 +45,8 @@ public class BookmarkRecipeService {
         recipe.decreaseBookmarkCount();
         bookmarkRecipeRepository.delete(bookmarkRecipe);
     }
+
+    public boolean checkBookmark(Long userId, Long recipeId){
+        return bookmarkRecipeRepository.existsByUserIdAndRecipeId(userId, recipeId);
+    }
 }

--- a/backend/src/main/java/org/youcancook/gobong/domain/recipe/dto/response/GetRecipeSummaryResponse.java
+++ b/backend/src/main/java/org/youcancook/gobong/domain/recipe/dto/response/GetRecipeSummaryResponse.java
@@ -21,5 +21,6 @@ public class GetRecipeSummaryResponse {
     private List<String> cookwares;
     private String difficulty;
     private Double averageRating;
+    private boolean isBookmarked;
 
 }

--- a/backend/src/main/java/org/youcancook/gobong/domain/recipe/dto/response/RecipeAuthorResponse.java
+++ b/backend/src/main/java/org/youcancook/gobong/domain/recipe/dto/response/RecipeAuthorResponse.java
@@ -12,6 +12,7 @@ public class RecipeAuthorResponse {
 
     private Long id;
     private String nickname;
+    private String profileImageURL;
     private boolean isFollowing;
     private boolean isMyself;
 }

--- a/backend/src/test/java/org/youcancook/gobong/domain/recipe/service/RecipeAcceptanceTest.java
+++ b/backend/src/test/java/org/youcancook/gobong/domain/recipe/service/RecipeAcceptanceTest.java
@@ -149,7 +149,7 @@ public class RecipeAcceptanceTest extends AcceptanceTest {
         }
 
         RestAssured.given().log().all()
-                .auth().oauth2(accessToken1)
+                .auth().oauth2(accessToken2)
                 .when().get("/api/feed/bookmarked?count=3")
                 .then().log().all()
                 .statusCode(HttpStatus.OK.value())


### PR DESCRIPTION
## 개요 🧾
<!-- 이곳에 PR의 내용을 간단하게 작성해주세요. -->
인수 테스트 시 잘못 들어가고있던 token 인자를 수정했습니다.
레시피 조회 Response에 글쓴이의 프로필사진 URL, 자신이 북마크했는지 여부를 추가했습니다.

## 주의사항 ⚠
<!-- 이곳에 리뷰어에게 할 말이나, 주의해야 하는 점에 대해서 작성해 주세요 -->
덕지덕지 붙이는 듯 썼는데, GetRecipeService가 readonly로만 작성될 예정이라 service 자체로는 괜찮을 것 같지만, 다른 의견이 있다면 언제든 환영...
