### PR TITLE
fix: 팔로워/팔로잉 리스트 쿼리 조건 추가, 팔로워 조회 시 팔로잉 여부 데이터 추가

### DIFF
--- a/backend/src/main/java/org/youcancook/gobong/domain/follow/dto/response/FindFollowerResponse.java
+++ b/backend/src/main/java/org/youcancook/gobong/domain/follow/dto/response/FindFollowerResponse.java
@@ -1,5 +1,6 @@
 package org.youcancook.gobong.domain.follow.dto.response;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -11,12 +12,15 @@ public class FindFollowerResponse {
     private long userId;
     private String nickname;
     private String profileImageURL;
+    @JsonProperty("isFollowed")
+    private Boolean isFollowed;
 
-    public static FindFollowerResponse of(long userId, String nickname, String profileImageURL) {
+    public static FindFollowerResponse of(long userId, String nickname, String profileImageURL, boolean isFollowed) {
         return FindFollowerResponse.builder()
                 .userId(userId)
                 .nickname(nickname)
                 .profileImageURL(profileImageURL)
+                .isFollowed(isFollowed)
                 .build();
     }
 }

--- a/backend/src/main/java/org/youcancook/gobong/domain/follow/repository/FollowRepository.java
+++ b/backend/src/main/java/org/youcancook/gobong/domain/follow/repository/FollowRepository.java
@@ -13,9 +13,9 @@ public interface FollowRepository extends JpaRepository<Follow, Long> {
 
     Optional<Follow> findByFollowerAndFollowee(User follower, User followee);
 
-    @Query("select f from Follow f join fetch f.follower")
+    @Query("select f from Follow f join fetch f.follower where f.followee = :followee")
     List<Follow> findByFollowee(User followee);
 
-    @Query("select f from Follow f join fetch f.followee")
+    @Query("select f from Follow f join fetch f.followee where f.follower = :follower")
     List<Follow> findByFollower(User follower);
 }

--- a/backend/src/main/java/org/youcancook/gobong/domain/follow/service/FollowService.java
+++ b/backend/src/main/java/org/youcancook/gobong/domain/follow/service/FollowService.java
@@ -60,12 +60,16 @@ public class FollowService {
     public List<FindFollowerResponse> findFollowerList(Long loginUserId) {
         User user = userRepository.findById(loginUserId)
                 .orElseThrow(UserNotFoundException::new);
+        List<Long> userFollowedMe = followRepository.findByFollower(user).stream()
+                .map(follow -> follow.getFollowee().getId())
+                .toList();
 
         return followRepository.findByFollowee(user).stream()
                 .map(follow -> FindFollowerResponse.of(
                         follow.getFollower().getId(),
                         follow.getFollower().getNickname(),
-                        follow.getFollower().getProfileImageURL()
+                        follow.getFollower().getProfileImageURL(),
+                        userFollowedMe.contains(follow.getFollower().getId())
                 ))
                 .toList();
     }
@@ -83,7 +87,7 @@ public class FollowService {
                 .toList();
     }
 
-    public boolean isFollowing(Long followerId, Long followeeId){
+    public boolean isFollowing(Long followerId, Long followeeId) {
         User follower = userRepository.findById(followerId)
                 .orElseThrow(UserNotFoundException::new);
         User followee = userRepository.findById(followeeId)

--- a/backend/src/test/java/org/youcancook/gobong/domain/follow/controller/FollowControllerTest.java
+++ b/backend/src/test/java/org/youcancook/gobong/domain/follow/controller/FollowControllerTest.java
@@ -1,7 +1,5 @@
 package org.youcancook.gobong.domain.follow.controller;
 
-import jakarta.persistence.EntityManager;
-import jakarta.persistence.PersistenceContext;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -43,9 +41,6 @@ class FollowControllerTest {
 
     @Autowired
     private TokenManager tokenManager;
-
-    @PersistenceContext
-    private EntityManager entityManager;
 
     private static int testUserCount = 0;
 
@@ -146,6 +141,10 @@ class FollowControllerTest {
                 .follower(follower1)
                 .followee(loginUser)
                 .build());
+        followRepository.save(Follow.builder()
+                .follower(loginUser)
+                .followee(follower1)
+                .build());
 
         User follower2 = saveTestUser();
         followRepository.save(Follow.builder()
@@ -153,7 +152,6 @@ class FollowControllerTest {
                 .followee(loginUser)
                 .build());
 
-        entityManager.clear();
         // when
         mockMvc.perform(get("/api/follower")
                         .header("Authorization", "Bearer " + accessToken))
@@ -165,6 +163,8 @@ class FollowControllerTest {
                 .andExpect(jsonPath("$.[?(@.nickname == '%s')]", follower2.getNickname()).exists())
                 .andExpect(jsonPath("$.[?(@.profileImageURL == '%s')]", follower1.getProfileImageURL()).exists())
                 .andExpect(jsonPath("$.[?(@.profileImageURL == '%s')]", follower2.getProfileImageURL()).exists())
+                .andExpect(jsonPath("$.[?(@.isFollowed == %b)]", true).exists())
+                .andExpect(jsonPath("$.[?(@.isFollowed == %b)]", false).exists())
                 .andDo(print());
     }
 
@@ -186,7 +186,6 @@ class FollowControllerTest {
                 .followee(followee2)
                 .build());
 
-        entityManager.clear();
         // when
         mockMvc.perform(get("/api/following")
                         .header("Authorization", "Bearer " + accessToken))


### PR DESCRIPTION
## 개요 🧾
팔로워/팔로잉 리스트 쿼리 조건 추가, 팔로워 조회 시 팔로잉 여부 데이터 추가

## 변경사항 🛠
```json
[
  {
    "userId": 10,
    "nickname": "nickname9",
    "profileImageURL": "profileImageURL9",
    "isFollowed": true
  },
  {
    "userId": 11,
    "nickname": "nickname10",
    "profileImageURL": "profileImageURL10",
    "isFollowed": false
  }
]
```

