### PR TITLE
feat: 유저 정보 변경 시, 현재와 동일한 닉네임이면 중복 확인을 하지 않도록 수정

### DIFF
--- a/backend/src/main/java/org/youcancook/gobong/domain/user/service/UserInformationService.java
+++ b/backend/src/main/java/org/youcancook/gobong/domain/user/service/UserInformationService.java
@@ -24,10 +24,12 @@ public class UserInformationService {
 
     @Transactional
     public void updateInformation(Long userId, String nickname, String profileImageURL) {
-        validateDuplicateNickname(nickname);
-
         User user = userRepository.findById(userId)
                 .orElseThrow(UserNotFoundException::new);
+        if (!user.getNickname().equals(nickname)) {
+            validateDuplicateNickname(nickname);
+        }
+
         user.updateNicknameAndProfileImageURL(nickname, profileImageURL);
     }
 

--- a/backend/src/test/java/org/youcancook/gobong/domain/user/service/UserInformationServiceTest.java
+++ b/backend/src/test/java/org/youcancook/gobong/domain/user/service/UserInformationServiceTest.java
@@ -72,6 +72,10 @@ class UserInformationServiceTest {
     @DisplayName("회원정보 수정 실패 - 중복된 닉네임")
     void updateInformationFailByDuplicatedNickname() {
         // given
+        User user = createTestUser();
+        Long userId = 1L;
+        when(userRepository.findById(userId))
+                .thenReturn(Optional.of(user));
         String newNickname = "newNickname";
         when(userRepository.existsByNickname(newNickname))
                 .thenReturn(true);

--- a/backend/src/test/java/org/youcancook/gobong/domain/user/service/UserInformationServiceTest.java
+++ b/backend/src/test/java/org/youcancook/gobong/domain/user/service/UserInformationServiceTest.java
@@ -83,7 +83,25 @@ class UserInformationServiceTest {
         // expect
         assertThrows(DuplicationNicknameException.class,
                 () -> userInformationService.updateInformation(1L, newNickname, "newProfileImageURL"));
+    }
 
+    @Test
+    @DisplayName("회원정보 수정 성공 - 같은 닉네임이면 중복 확인을 하지 않음")
+    void updateInformationSuccessWhenEqualNickname() {
+        // given
+        User user = createTestUser();
+        Long userId = 1L;
+        when(userRepository.findById(userId))
+                .thenReturn(Optional.of(user));
+
+        // expect
+        String userNickname = user.getNickname();
+        String newProfileImageURL = "newProfileImageURL";
+        userInformationService.updateInformation(userId, userNickname, newProfileImageURL);
+
+        // then
+        assertThat(user.getNickname()).isEqualTo(userNickname);
+        assertThat(user.getProfileImageURL()).isEqualTo(newProfileImageURL);
     }
 
     private User createTestUser() {


### PR DESCRIPTION
## 개요 🧾
 유저 정보 변경 시, 현재와 동일한 닉네임이면 중복 확인을 하지 않도록 수정

