### PR TITLE
feat: 유저 정보 조회 시, 팔로우/팔로잉 인원수와 작성한 레시피 개수도 포함해서 반환해주도록 변경

### DIFF
--- a/backend/src/main/java/org/youcancook/gobong/domain/follow/repository/FollowRepository.java
+++ b/backend/src/main/java/org/youcancook/gobong/domain/follow/repository/FollowRepository.java
@@ -18,4 +18,8 @@ public interface FollowRepository extends JpaRepository<Follow, Long> {
 
     @Query("select f from Follow f join fetch f.followee where f.follower = :follower")
     List<Follow> findByFollower(User follower);
+
+    Long countByFollower(User user);
+
+    Long countByFollowee(User user);
 }

--- a/backend/src/main/java/org/youcancook/gobong/domain/recipe/repository/RecipeRepository.java
+++ b/backend/src/main/java/org/youcancook/gobong/domain/recipe/repository/RecipeRepository.java
@@ -5,6 +5,7 @@ import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.youcancook.gobong.domain.recipe.entity.Recipe;
+import org.youcancook.gobong.domain.user.entity.User;
 
 import java.util.Optional;
 
@@ -28,4 +29,6 @@ public interface RecipeRepository extends JpaRepository<Recipe, Long> {
             "WHERE (r.user.id IN (SELECT f.followee.id FROM Follow f WHERE f.follower.id =:userId) OR r.user.id =:userId) " +
             "AND r.id <:recipeId")
     Slice<Recipe> getAllFollowingFeed(Long userId, long recipeId, PageRequest of);
+
+    Long countByUser(User user);
 }

--- a/backend/src/main/java/org/youcancook/gobong/domain/user/dto/response/UserInformationResponse.java
+++ b/backend/src/main/java/org/youcancook/gobong/domain/user/dto/response/UserInformationResponse.java
@@ -13,16 +13,22 @@ public class UserInformationResponse {
     private Long id;
     private String nickname;
     private String profileImageURL;
+    private long followerNumber;
+    private long followingNumber;
+    private long recipeNumber;
 
     @JsonProperty("oAuthProvider")
     private String oauthProvider;
 
-    public static UserInformationResponse from(User user) {
+    public static UserInformationResponse of(User user, long followerNumber, long followingNumber, long recipeNumber) {
         return UserInformationResponse.builder()
                 .id(user.getId())
                 .nickname(user.getNickname())
                 .profileImageURL(user.getProfileImageURL())
                 .oauthProvider(user.getOAuthProvider().name())
+                .followerNumber(followerNumber)
+                .followingNumber(followingNumber)
+                .recipeNumber(recipeNumber)
                 .build();
     }
 }

--- a/backend/src/main/java/org/youcancook/gobong/domain/user/service/UserInformationService.java
+++ b/backend/src/main/java/org/youcancook/gobong/domain/user/service/UserInformationService.java
@@ -3,6 +3,8 @@ package org.youcancook.gobong.domain.user.service;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.youcancook.gobong.domain.follow.repository.FollowRepository;
+import org.youcancook.gobong.domain.recipe.repository.RecipeRepository;
 import org.youcancook.gobong.domain.user.dto.response.UserInformationResponse;
 import org.youcancook.gobong.domain.user.entity.User;
 import org.youcancook.gobong.domain.user.exception.DuplicationNicknameException;
@@ -15,11 +17,16 @@ import org.youcancook.gobong.domain.user.repository.UserRepository;
 public class UserInformationService {
 
     private final UserRepository userRepository;
+    private final FollowRepository followRepository;
+    private final RecipeRepository recipeRepository;
 
     public UserInformationResponse getUserInformation(Long userId) {
         User user = userRepository.findById(userId)
                 .orElseThrow(UserNotFoundException::new);
-        return UserInformationResponse.from(user);
+        Long followeeNumber = followRepository.countByFollower(user);
+        Long followerNumber = followRepository.countByFollowee(user);
+        Long recipeNumber = recipeRepository.countByUser(user);
+        return UserInformationResponse.of(user, followerNumber, followeeNumber, recipeNumber);
     }
 
     @Transactional

--- a/backend/src/test/java/org/youcancook/gobong/domain/user/service/UserInformationServiceTest.java
+++ b/backend/src/test/java/org/youcancook/gobong/domain/user/service/UserInformationServiceTest.java
@@ -7,6 +7,8 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.test.util.ReflectionTestUtils;
+import org.youcancook.gobong.domain.follow.repository.FollowRepository;
+import org.youcancook.gobong.domain.recipe.repository.RecipeRepository;
 import org.youcancook.gobong.domain.user.dto.response.UserInformationResponse;
 import org.youcancook.gobong.domain.user.entity.OAuthProvider;
 import org.youcancook.gobong.domain.user.entity.User;
@@ -28,6 +30,12 @@ class UserInformationServiceTest {
     @Mock
     private UserRepository userRepository;
 
+    @Mock
+    private FollowRepository followRepository;
+
+    @Mock
+    private RecipeRepository recipeRepository;
+
     @Test
     @DisplayName("회원정보 조회")
     void checkInformation() {
@@ -36,7 +44,12 @@ class UserInformationServiceTest {
         ReflectionTestUtils.setField(user, "id", 1L);
         when(userRepository.findById(user.getId()))
                 .thenReturn(Optional.of(user));
-
+        when(followRepository.countByFollower(user))
+                .thenReturn(5L);
+        when(followRepository.countByFollowee(user))
+                .thenReturn(3L);
+        when(recipeRepository.countByUser(user))
+                .thenReturn(1L);
         // when
         UserInformationResponse result = userInformationService.getUserInformation(user.getId());
 
@@ -45,6 +58,9 @@ class UserInformationServiceTest {
         assertThat(result.getNickname()).isEqualTo(user.getNickname());
         assertThat(result.getOauthProvider()).isEqualTo(user.getOAuthProvider().name());
         assertThat(result.getProfileImageURL()).isEqualTo(user.getProfileImageURL());
+        assertThat(result.getFollowingNumber()).isEqualTo(5L);
+        assertThat(result.getFollowerNumber()).isEqualTo(3L);
+        assertThat(result.getRecipeNumber()).isEqualTo(1L);
     }
 
     @Test


### PR DESCRIPTION
## 개요 🧾
유저 정보 조회 시, 팔로우/팔로잉 인원수와 작성한 레시피 개수도 포함해서 반환해주도록 변경