### PR TITLE
feat: 필터 검색 기능 구현

### DIFF
--- a/backend/src/main/java/org/youcancook/gobong/domain/recipe/controller/FeedController.java
+++ b/backend/src/main/java/org/youcancook/gobong/domain/recipe/controller/FeedController.java
@@ -1,11 +1,12 @@
 package org.youcancook.gobong.domain.recipe.controller;
 
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
+import org.youcancook.gobong.domain.recipe.dto.feedfilterdto.FeedFilterDto;
+import org.youcancook.gobong.domain.recipe.dto.feedfilterdto.ModifiedFeedFilterDto;
+import org.youcancook.gobong.domain.recipe.dto.feedfilterdto.QueryType;
 import org.youcancook.gobong.domain.recipe.dto.response.GetFeedResponse;
 import org.youcancook.gobong.domain.recipe.service.GetRecipeService;
 import org.youcancook.gobong.global.resolver.LoginUserId;
@@ -42,5 +43,18 @@ public class FeedController {
         GetFeedResponse response = getRecipeService.getFollowingFeed(userId, lastRecipeId, count);
         return ResponseEntity.ok(response);
     }
+
+    @PostMapping("filter")
+    public ResponseEntity<GetFeedResponse> getFilteredFeedByTitle(@LoginUserId Long userId,
+                                                           @RequestParam(name = "page", required = true) int page,
+                                                           @RequestParam(name = "count", required = true) int count,
+                                                           @RequestBody @Valid FeedFilterDto filter){
+        ModifiedFeedFilterDto modifiedFilter = ModifiedFeedFilterDto.from(filter);
+        GetFeedResponse response = modifiedFilter.getQueryType() == QueryType.TITLE ?
+                getRecipeService.getFilteredFeedByName(userId, count, page, modifiedFilter) :
+                getRecipeService.getFilteredFeedByRecipeTitle(userId, count, page, modifiedFilter);
+        return ResponseEntity.ok(response);
+    }
+
 
 }

--- a/backend/src/main/java/org/youcancook/gobong/domain/recipe/dto/feedfilterdto/FeedFilterDto.java
+++ b/backend/src/main/java/org/youcancook/gobong/domain/recipe/dto/feedfilterdto/FeedFilterDto.java
@@ -1,0 +1,29 @@
+package org.youcancook.gobong.domain.recipe.dto.feedfilterdto;
+
+import jakarta.validation.constraints.NotNull;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class FeedFilterDto {
+
+    private String query;
+
+    @NotNull(message = "정렬 기준은 필수 항목입니다.")
+    private String filterType;
+
+    private String difficulty;
+
+    private Integer maxTotalCookTime;
+
+    private Integer minRating;
+
+    private List<String> cookwares;
+
+}

--- a/backend/src/main/java/org/youcancook/gobong/domain/recipe/dto/feedfilterdto/FilterType.java
+++ b/backend/src/main/java/org/youcancook/gobong/domain/recipe/dto/feedfilterdto/FilterType.java
@@ -1,0 +1,16 @@
+package org.youcancook.gobong.domain.recipe.dto.feedfilterdto;
+
+import org.youcancook.gobong.domain.recipe.exception.IllegalFilterTypeException;
+
+import java.util.Arrays;
+
+public enum FilterType {
+    RECENT, POPULAR;
+
+    public static FilterType from(String value){
+        return Arrays.stream(values())
+                .filter(filterType -> filterType.name().equalsIgnoreCase(value))
+                .findFirst()
+                .orElseThrow(IllegalFilterTypeException::new);
+    }
+}

--- a/backend/src/main/java/org/youcancook/gobong/domain/recipe/dto/feedfilterdto/ModifiedFeedFilterDto.java
+++ b/backend/src/main/java/org/youcancook/gobong/domain/recipe/dto/feedfilterdto/ModifiedFeedFilterDto.java
@@ -1,0 +1,39 @@
+package org.youcancook.gobong.domain.recipe.dto.feedfilterdto;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.youcancook.gobong.domain.recipe.entity.Cookware;
+import org.youcancook.gobong.domain.recipe.entity.Difficulty;
+
+import java.util.List;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ModifiedFeedFilterDto {
+
+    private String query;
+    private QueryType queryType;
+    private FilterType filterType;
+    private List<Difficulty> difficulties;
+    private Integer maxTotalCookTime;
+    private Integer minRating;
+    private Long cookwares;
+
+    public static ModifiedFeedFilterDto from(FeedFilterDto dto){
+        ModifiedFeedFilterDto modifiedDto = new ModifiedFeedFilterDto();
+
+        modifiedDto.queryType = dto.getQuery().startsWith("@") ? QueryType.AUTHOR_NAME : QueryType.TITLE;
+        modifiedDto.query = dto.getQuery();
+        modifiedDto.filterType = FilterType.from(dto.getFilterType());
+        modifiedDto.difficulties = dto.getDifficulty() == null ? List.of(Difficulty.EASY, Difficulty.NORMAL, Difficulty.HARD)
+                : List.of(Difficulty.from(dto.getDifficulty()));
+        modifiedDto.maxTotalCookTime = dto.getMaxTotalCookTime() == null ? Integer.MAX_VALUE : dto.getMaxTotalCookTime();
+        modifiedDto.minRating = dto.getMinRating() == null ? 0 : dto.getMinRating();
+        modifiedDto.cookwares = Cookware.namesToCookwareBit(dto.getCookwares());
+
+        return modifiedDto;
+    }
+}

--- a/backend/src/main/java/org/youcancook/gobong/domain/recipe/dto/feedfilterdto/QueryType.java
+++ b/backend/src/main/java/org/youcancook/gobong/domain/recipe/dto/feedfilterdto/QueryType.java
@@ -1,0 +1,16 @@
+package org.youcancook.gobong.domain.recipe.dto.feedfilterdto;
+
+import org.youcancook.gobong.domain.recipe.exception.IllegalQueryTypeException;
+
+import java.util.Arrays;
+
+public enum QueryType {
+    TITLE, AUTHOR_NAME;
+
+    public static QueryType from(String value){
+        return Arrays.stream(values())
+                .filter(queryType -> queryType.name().equalsIgnoreCase(value))
+                .findFirst()
+                .orElseThrow(IllegalQueryTypeException::new);
+    }
+}

--- a/backend/src/main/java/org/youcancook/gobong/domain/recipe/exception/IllegalFilterTypeException.java
+++ b/backend/src/main/java/org/youcancook/gobong/domain/recipe/exception/IllegalFilterTypeException.java
@@ -1,0 +1,10 @@
+package org.youcancook.gobong.domain.recipe.exception;
+
+import org.youcancook.gobong.global.error.ErrorCode;
+import org.youcancook.gobong.global.error.exception.BusinessException;
+
+public class IllegalFilterTypeException extends BusinessException {
+    public IllegalFilterTypeException() {
+        super(ErrorCode.INVALID_FILTER_TYPE);
+    }
+}

--- a/backend/src/main/java/org/youcancook/gobong/domain/recipe/exception/IllegalQueryTypeException.java
+++ b/backend/src/main/java/org/youcancook/gobong/domain/recipe/exception/IllegalQueryTypeException.java
@@ -1,0 +1,10 @@
+package org.youcancook.gobong.domain.recipe.exception;
+
+import org.youcancook.gobong.global.error.ErrorCode;
+import org.youcancook.gobong.global.error.exception.BusinessException;
+
+public class IllegalQueryTypeException extends BusinessException {
+    public IllegalQueryTypeException() {
+        super(ErrorCode.INVALID_QUERY_TYPE);
+    }
+}

--- a/backend/src/main/java/org/youcancook/gobong/domain/recipe/repository/RecipeRepository.java
+++ b/backend/src/main/java/org/youcancook/gobong/domain/recipe/repository/RecipeRepository.java
@@ -4,8 +4,10 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import org.youcancook.gobong.domain.recipe.entity.Difficulty;
 import org.youcancook.gobong.domain.recipe.entity.Recipe;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface RecipeRepository extends JpaRepository<Recipe, Long> {
@@ -28,4 +30,24 @@ public interface RecipeRepository extends JpaRepository<Recipe, Long> {
             "WHERE (r.user.id IN (SELECT f.followee.id FROM Follow f WHERE f.follower.id =:userId) OR r.user.id =:userId) " +
             "AND r.id <:recipeId")
     Slice<Recipe> getAllFollowingFeed(Long userId, long recipeId, PageRequest of);
+
+    @Query(value = "SELECT r FROM Recipe r " +
+            "WHERE r.title LIKE %:query% " +
+            "AND r.difficulty IN :difficulties " +
+            "AND r.totalCookTimeInSeconds <=:maxTotalCookTime " +
+            "AND (CASE r.totalRatedNum WHEN 0 THEN 0 ELSE (r.totalRating/r.totalRatedNum) END) >=:minRating " +
+            "AND BITAND(r.cookwares, CAST(:cookwares AS long)) = :cookwares")
+    Slice<Recipe> getFilteredFeedByRecipeTitle(String query, List<Difficulty> difficulties, int maxTotalCookTime,
+                                               int minRating, long cookwares, PageRequest of);
+
+
+    @Query(value = "SELECT r FROM Recipe r " +
+            "JOIN r.user u " +
+            "WHERE u.nickname =:query " +
+            "AND r.difficulty IN :difficulties " +
+            "AND r.totalCookTimeInSeconds <=:maxTotalCookTime " +
+            "AND (CASE r.totalRatedNum WHEN 0 THEN 0 ELSE (r.totalRating/r.totalRatedNum) END) >=:minRating " +
+            "AND BITAND(r.cookwares, CAST(:cookwares AS long)) = :cookwares ")
+    Slice<Recipe> getFilteredFeedByAuthorName(String query, List<Difficulty> difficulties, int maxTotalCookTime,
+                                              int minRating, long cookwares, PageRequest of);
 }

--- a/backend/src/main/java/org/youcancook/gobong/domain/recipe/service/GetRecipeService.java
+++ b/backend/src/main/java/org/youcancook/gobong/domain/recipe/service/GetRecipeService.java
@@ -1,12 +1,12 @@
 package org.youcancook.gobong.domain.recipe.service;
 
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.PageRequest;
-import org.springframework.data.domain.Slice;
-import org.springframework.data.domain.Sort;
+import org.springframework.data.domain.*;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.youcancook.gobong.domain.follow.service.FollowService;
+import org.youcancook.gobong.domain.recipe.dto.feedfilterdto.FilterType;
+import org.youcancook.gobong.domain.recipe.dto.feedfilterdto.ModifiedFeedFilterDto;
 import org.youcancook.gobong.domain.recipe.dto.recipeDto.RecipeDto;
 import org.youcancook.gobong.domain.recipe.dto.response.GetFeedResponse;
 import org.youcancook.gobong.domain.recipe.dto.response.GetRecipeResponse;
@@ -73,6 +73,24 @@ public class GetRecipeService {
     public GetFeedResponse getFollowingFeed(Long userId, long recipeId, int count){
         Slice<Recipe> feedRecipes = recipeRepository.getAllFollowingFeed(userId, recipeId,
                 PageRequest.of(0, count, Sort.by("id").descending()));
+        return getFeedResponse(userId, feedRecipes);
+    }
+
+    public GetFeedResponse getFilteredFeedByName(Long userId, int page, int count, ModifiedFeedFilterDto filter){
+        String sortProperty = filter.getFilterType() == FilterType.RECENT ? "id" : "totalBookmarkCount";
+
+        Slice<Recipe> feedRecipes = recipeRepository.getFilteredFeedByRecipeTitle(filter.getQuery(),
+                filter.getDifficulties(), filter.getMaxTotalCookTime(), filter.getMinRating(),
+                filter.getCookwares(), PageRequest.of(page, count, Sort.by(sortProperty).descending()));
+        return getFeedResponse(userId, feedRecipes);
+    }
+
+    public GetFeedResponse getFilteredFeedByRecipeTitle(Long userId, int page, int count, ModifiedFeedFilterDto filter){
+        String sortProperty = filter.getFilterType() == FilterType.RECENT ? "id" : "totalBookmarkCount";
+
+        Slice<Recipe> feedRecipes = recipeRepository.getFilteredFeedByAuthorName(filter.getQuery(),
+                filter.getDifficulties(), filter.getMaxTotalCookTime(), filter.getMinRating(),
+                filter.getCookwares(), PageRequest.of(page, count, Sort.by(sortProperty).descending()));
         return getFeedResponse(userId, feedRecipes);
     }
 

--- a/backend/src/main/java/org/youcancook/gobong/global/error/ErrorCode.java
+++ b/backend/src/main/java/org/youcancook/gobong/global/error/ErrorCode.java
@@ -66,7 +66,13 @@ public enum ErrorCode {
     NOT_FOLLOWING(HttpStatus.BAD_REQUEST, "F102", "팔로우하지 않은 사용자입니다."),
 
     // Cookwares
-    ILLEGAL_COOKWARE(HttpStatus.NOT_FOUND, "C104", "존재하지 않는 조리기구입니다.");
+    ILLEGAL_COOKWARE(HttpStatus.NOT_FOUND, "C104", "존재하지 않는 조리기구입니다."),
+
+    // FilterType
+    INVALID_FILTER_TYPE(HttpStatus.BAD_REQUEST, "F201", "필터 타입은 'recent', 'popular' 중 하나여야 합니다."),
+    INVALID_QUERY_TYPE(HttpStatus.BAD_REQUEST, "F202", "쿼리 필터 타입은 'name', 'authorName' 중 하나여야 합니다."),
+
+    ;
 
     private final HttpStatus status;
     private final String code;

--- a/backend/src/test/java/org/youcancook/gobong/domain/recipe/repository/RecipeRepositoryTest.java
+++ b/backend/src/test/java/org/youcancook/gobong/domain/recipe/repository/RecipeRepositoryTest.java
@@ -1,0 +1,166 @@
+package org.youcancook.gobong.domain.recipe.repository;
+
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Slice;
+import org.springframework.data.domain.Sort;
+import org.youcancook.gobong.domain.rating.entity.Rating;
+import org.youcancook.gobong.domain.rating.repository.RatingRepository;
+import org.youcancook.gobong.domain.recipe.entity.Cookware;
+import org.youcancook.gobong.domain.recipe.entity.Difficulty;
+import org.youcancook.gobong.domain.recipe.entity.Recipe;
+import org.youcancook.gobong.domain.user.entity.OAuthProvider;
+import org.youcancook.gobong.domain.user.entity.User;
+import org.youcancook.gobong.domain.user.repository.UserRepository;
+
+import java.util.List;
+
+@DataJpaTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+class RecipeRepositoryTest {
+
+    @Autowired
+    UserRepository userRepository;
+    @Autowired
+    RecipeRepository recipeRepository;
+    @Autowired
+    RatingRepository ratingRepository;
+
+    @Test
+    @DisplayName("조리기구 필터링이 잘 작동한다.")
+    public void filterByCookware(){
+        User user = new User("쩝쩝박사", "123", OAuthProvider.GOOGLE, null);
+        Long id = userRepository.save(user).getId();
+
+        Recipe recipe1 = new Recipe(user, "김밥", "김밥이에요", "김,밥", Difficulty.EASY, null);
+        recipe1.addCookware(Cookware.MICROWAVE.getValue() | Cookware.AIR_FRYER.getValue());
+        recipeRepository.save(recipe1);
+
+        Recipe recipe2 = new Recipe(user, "김밥", "김밥이에요", "김,밥", Difficulty.EASY, null);
+        recipe2.addCookware(Cookware.AIR_FRYER.getValue());
+        recipeRepository.save(recipe2);
+
+        Recipe recipe3 = new Recipe(user, "김밥", "김밥이에요", "김,밥", Difficulty.EASY, null);
+        recipe3.addCookware(Cookware.MICROWAVE.getValue() | Cookware.PAN.getValue());
+        recipeRepository.save(recipe3);
+
+        Slice<Recipe> actual = recipeRepository.getFilteredFeedByRecipeTitle("", List.of(Difficulty.EASY, Difficulty.NORMAL, Difficulty.HARD),
+                Integer.MAX_VALUE, 0, Cookware.MICROWAVE.getValue(), PageRequest.of(0, 3, Sort.by("id").descending()));
+
+        Assertions.assertThat(actual.getContent()).hasSize(2);
+
+    }
+
+    @Test
+    @DisplayName("난이도 필터링이 잘 작동한다.")
+    public void filterByDifficulty(){
+        User user = new User("쩝쩝박사", "123", OAuthProvider.GOOGLE, null);
+        Long id = userRepository.save(user).getId();
+
+        Recipe recipe1 = new Recipe(user, "김밥", "김밥이에요", "김,밥", Difficulty.EASY, null);
+        recipe1.addCookware(Cookware.MICROWAVE.getValue() | Cookware.AIR_FRYER.getValue());
+        recipeRepository.save(recipe1);
+
+        Recipe recipe2 = new Recipe(user, "김밥", "김밥이에요", "김,밥", Difficulty.NORMAL, null);
+        recipe2.addCookware(Cookware.AIR_FRYER.getValue());
+        recipeRepository.save(recipe2);
+
+        Recipe recipe3 = new Recipe(user, "김밥", "김밥이에요", "김,밥", Difficulty.NORMAL, null);
+        recipe3.addCookware(Cookware.MICROWAVE.getValue() | Cookware.PAN.getValue());
+        recipeRepository.save(recipe3);
+
+        Slice<Recipe> actual = recipeRepository.getFilteredFeedByRecipeTitle("", List.of(Difficulty.EASY),
+                Integer.MAX_VALUE, 0, 0, PageRequest.of(0, 3, Sort.by("id").descending()));
+
+        Assertions.assertThat(actual.getContent()).hasSize(1);
+    }
+
+    @Test
+    @DisplayName("최대 조리시간 필터링이 잘 작동한다.")
+    public void filterByMaxCookTime(){
+        User user = new User("쩝쩝박사", "123", OAuthProvider.GOOGLE, null);
+        Long id = userRepository.save(user).getId();
+
+        Recipe recipe1 = new Recipe(user, "김밥", "김밥이에요", "김,밥", Difficulty.EASY, null);
+        recipe1.addCookware(Cookware.MICROWAVE.getValue() | Cookware.AIR_FRYER.getValue());
+        recipe1.addCookTime(10);
+        recipeRepository.save(recipe1);
+
+        Recipe recipe2 = new Recipe(user, "김밥", "김밥이에요", "김,밥", Difficulty.NORMAL, null);
+        recipe2.addCookware(Cookware.AIR_FRYER.getValue());
+        recipe1.addCookTime(20);
+        recipeRepository.save(recipe2);
+
+        Recipe recipe3 = new Recipe(user, "김밥", "김밥이에요", "김,밥", Difficulty.NORMAL, null);
+        recipe3.addCookware(Cookware.MICROWAVE.getValue() | Cookware.PAN.getValue());
+        recipe1.addCookTime(30);
+        recipeRepository.save(recipe3);
+
+        Slice<Recipe> actual = recipeRepository.getFilteredFeedByRecipeTitle("", List.of(Difficulty.EASY, Difficulty.NORMAL, Difficulty.HARD),
+                25, 0, 0, PageRequest.of(0, 3, Sort.by("id").descending()));
+
+        Assertions.assertThat(actual.getContent()).hasSize(2);
+    }
+
+    @Test
+    @DisplayName("최소 평점 필터링이 잘 작동한다.")
+    public void filterByMinRating(){
+        User user = new User("쩝쩝박사", "123", OAuthProvider.GOOGLE, null);
+        Long id = userRepository.save(user).getId();
+
+        User guest1 = new User("guest1", "1234", OAuthProvider.GOOGLE, null);
+        userRepository.save(guest1);
+        User guest2 = new User("guest2", "12354", OAuthProvider.GOOGLE, null);
+        userRepository.save(guest2);
+
+        Recipe recipe1 = new Recipe(user, "김밥", "김밥이에요", "김,밥", Difficulty.EASY, null);
+        ratingRepository.save(new Rating(guest1, recipe1, 5));
+        ratingRepository.save(new Rating(guest2, recipe1, 1));
+        recipeRepository.save(recipe1);
+
+        Recipe recipe2 = new Recipe(user, "김밥", "김밥이에요", "김,밥", Difficulty.NORMAL, null);
+        ratingRepository.save(new Rating(guest1, recipe2, 4));
+        ratingRepository.save(new Rating(guest2, recipe2, 2));
+        recipeRepository.save(recipe2);
+
+        Recipe recipe3 = new Recipe(user, "김밥", "김밥이에요", "김,밥", Difficulty.NORMAL, null);
+        ratingRepository.save(new Rating(guest1, recipe3, 1));
+        ratingRepository.save(new Rating(guest2, recipe3, 3));
+        recipeRepository.save(recipe3);
+
+        Slice<Recipe> actual = recipeRepository.getFilteredFeedByRecipeTitle("", List.of(Difficulty.EASY, Difficulty.NORMAL, Difficulty.HARD),
+                Integer.MAX_VALUE, 3, 0, PageRequest.of(0, 3, Sort.by("id").descending()));
+
+        Assertions.assertThat(actual.getContent()).hasSize(2);
+    }
+
+    @Test
+    @DisplayName("이름 기준 필터링이 잘 작동한다.")
+    public void filterByName(){
+        User user = new User("쩝쩝박사", "123", OAuthProvider.GOOGLE, null);
+        Long id = userRepository.save(user).getId();
+
+        Recipe recipe1 = new Recipe(user, "김밥", "김밥이에요", "김,밥", Difficulty.EASY, null);
+        recipe1.addCookware(Cookware.MICROWAVE.getValue() | Cookware.AIR_FRYER.getValue());
+        recipeRepository.save(recipe1);
+
+        Recipe recipe2 = new Recipe(user, "김밥", "김밥이에요", "김,밥", Difficulty.EASY, null);
+        recipe2.addCookware(Cookware.AIR_FRYER.getValue());
+        recipeRepository.save(recipe2);
+
+        Recipe recipe3 = new Recipe(user, "김밥", "김밥이에요", "김,밥", Difficulty.HARD, null);
+        recipe3.addCookware(Cookware.MICROWAVE.getValue() | Cookware.PAN.getValue());
+        recipeRepository.save(recipe3);
+
+        Slice<Recipe> actual = recipeRepository.getFilteredFeedByAuthorName("쩝쩝박사", List.of(Difficulty.EASY),
+                Integer.MAX_VALUE, 0, 0, PageRequest.of(0, 3, Sort.by("id").descending()));
+
+        Assertions.assertThat(actual.getContent()).hasSize(2);
+
+    }
+}


### PR DESCRIPTION
## 개요 🧾
<!-- 이곳에 PR의 내용을 간단하게 작성해주세요. -->

API `/api/feed/filter?page={page}&count={count}` POST, requestBody도 있습니다
`feedFilterDto`로 받아온 다음, `modifiedFeedFilterDto`로 변환합니다. (도메인 단위)
이후 modifiedFeedFilterDto는 정규화되어 있으므로, 해당 dto를 사용해서 레포지토리에 전달합니다.

Repository에서 JPQL을 날리는 게 참 어렵습ㄴ디ㅏ.... 이 친구는 북마크 때문에 Offset을 사용했습니다
JPQL에서 Bitwise AND operation이 될지는 모르겠지만 MySQL에서도 잘 됐으면 좋겠네요

## 주의사항 ⚠
<!-- 이곳에 리뷰어에게 할 말이나, 주의해야 하는 점에 대해서 작성해 주세요 -->

`feedFilterDto`로 받은 것을 `modifiedFeedFilterDto`로 변환하는 게 맞는지 의문이 듭니다. 한번 확인해 주세요~!
