### PR TITLE
fix: 필터링 쿼리가 null일 경우 빈 값으로 치환하도록 수정

### DIFF
--- a/backend/src/main/java/org/youcancook/gobong/domain/recipe/dto/feedfilterdto/ModifiedFeedFilterDto.java
+++ b/backend/src/main/java/org/youcancook/gobong/domain/recipe/dto/feedfilterdto/ModifiedFeedFilterDto.java
@@ -25,8 +25,16 @@ public class ModifiedFeedFilterDto {
     public static ModifiedFeedFilterDto from(FeedFilterDto dto){
         ModifiedFeedFilterDto modifiedDto = new ModifiedFeedFilterDto();
 
-        modifiedDto.queryType = dto.getQuery().startsWith("@") ? QueryType.AUTHOR_NAME : QueryType.TITLE;
-        modifiedDto.query = dto.getQuery();
+        modifiedDto.query = dto.getQuery() == null ? "" : dto.getQuery();
+
+        if (modifiedDto.getQuery().startsWith("@")){
+            modifiedDto.queryType = QueryType.AUTHOR_NAME;
+            modifiedDto.query = modifiedDto.query.substring(1);
+        }
+        else{
+            modifiedDto.queryType = QueryType.TITLE;
+        }
+
         modifiedDto.filterType = FilterType.from(dto.getFilterType());
         modifiedDto.difficulties = dto.getDifficulty() == null ? List.of(Difficulty.EASY, Difficulty.NORMAL, Difficulty.HARD)
                 : List.of(Difficulty.from(dto.getDifficulty()));


### PR DESCRIPTION
## 개요 🧾
<!-- 이곳에 PR의 내용을 간단하게 작성해주세요. -->

Request에서 `query`의 값이 `null`일 경우, `startsWith`가 `NullPointerException`을 날리던 버그가 있었습니다.
해당 커밋에서는 이를 수정했습니다.
